### PR TITLE
Tao 1918 proctor authorization is required

### DIFF
--- a/controller/DeliveryServer.php
+++ b/controller/DeliveryServer.php
@@ -21,7 +21,9 @@
 namespace oat\taoProctoring\controller;
 
 use oat\taoProctoring\model\implementation\DeliveryService;
-use \common_session_SessionManager;
+use PHPSession;
+use common_Logger;
+use common_session_SessionManager;
 
 /**
  * Override the default DeliveryServer Controller
@@ -30,6 +32,19 @@ use \common_session_SessionManager;
  */
 class DeliveryServer extends \taoDelivery_actions_DeliveryServer
 {
+    /**
+     * The name of the secure key used to grant proctor authorisation.
+     * If the secure key is not set, or its value is not the same with the access key, 
+     * the test taker must wait for proctor authorization
+     */
+    const SECURE_KEY_NAME = 'proctor_secure_key';
+    
+    /**
+     * The name of the access key used to grant proctor authorisation.
+     * If the access key is not set, or its value is not the same with the secure key, 
+     * the test taker must wait for proctor authorization
+     */
+    const ACCESS_KEY_NAME = 'proctor_access_key';
 
     /**
      * constructor: initialize the service and the default data
@@ -41,17 +56,21 @@ class DeliveryServer extends \taoDelivery_actions_DeliveryServer
     }
 
     /**
-     * Override the content extension data
+     * Overrides the content extension data
      * @see {@link \taoDelivery_actions_DeliveryServer}
      */
     public function index()
     {
         parent::index();
         $this->setData('content-extension', 'taoProctoring');
+        
+        // if the test taker passes by this page, he/she cannot access to any delivery without proctor authorization,
+        // whatever the delivery execution status is.
+        $this->revokeAuthorization();
     }
 
     /**
-     * Override the return URL
+     * Overrides the return URL
      * @return string the URL
      */
     protected function getReturnUrl()
@@ -60,10 +79,14 @@ class DeliveryServer extends \taoDelivery_actions_DeliveryServer
     }
     
     /**
-     * Overwrite the parent initDeliveryExecution()
-     * Forward the test taker to the awaitingAuthorization page after delivery initialization
+     * Overwrites the parent initDeliveryExecution()
+     * Redirects the test taker to the awaitingAuthorization page after delivery initialization
      */
-    public function initDeliveryExecution() {
+    public function initDeliveryExecution() 
+    {
+        // from this page the test taker can only goes to the awaiting page, so always revoke authorization
+        $this->revokeAuthorization();
+        
         $deliveryExecution = $this->_initDeliveryExecution();
 	    $this->redirect(_url('awaitingAuthorization', null, null, array('init' => true, 'deliveryExecution' => $deliveryExecution->getIdentifier())));
 	}
@@ -73,23 +96,25 @@ class DeliveryServer extends \taoDelivery_actions_DeliveryServer
      *
      * @throws common_exception_Error
      */
-    public function runDeliveryExecution() {
+    public function runDeliveryExecution() 
+    {
         $deliveryExecution = $this->getCurrentDeliveryExecution();
         $deliveryService = $this->getServiceManager()->get(DeliveryService::CONFIG_ID);
         $executionState = $deliveryService->getState($deliveryExecution);
-
-        if (DeliveryService::STATE_AUTHORIZED == $executionState) {
+        
+        if (DeliveryService::STATE_AUTHORIZED == $executionState && $this->checkAuthorization()) {
             // the test taker is authorized to run the delivery
             // but a change is needed to make the delivery execution processable
             $deliveryService->resumeExecution($deliveryExecution);
             $executionState = $deliveryService->getState($deliveryExecution);
         }
 
-        if (DeliveryService::STATE_INPROGRESS != $executionState) {
+        if (DeliveryService::STATE_INPROGRESS != $executionState ||
+            (DeliveryService::STATE_INPROGRESS == $executionState && !$this->checkAuthorization())) {
             // the test taker is not allowed to run the delivery
             // so we redirect him/her to the awaiting page
-            \common_Logger::i(get_called_class() . '::runDeliveryExecution(): try to run delivery without proctor authorization for delivery execution ' . $deliveryExecution->getIdentifier() . ' with state ' . $executionState);
-            return $this->forward('awaitingAuthorization');
+            common_Logger::i(get_called_class() . '::runDeliveryExecution(): try to run delivery without proctor authorization for delivery execution ' . $deliveryExecution->getIdentifier() . ' with state ' . $executionState);
+            return $this->redirect(_url('awaitingAuthorization', null, null, array('init' => true, 'deliveryExecution' => $deliveryExecution->getIdentifier())));
         }
 
         // ok, the delivery execution can be processed
@@ -99,19 +124,30 @@ class DeliveryServer extends \taoDelivery_actions_DeliveryServer
     /**
      * The awaiting authorization screen
      */
-    public function awaitingAuthorization() {
-
+    public function awaitingAuthorization() 
+    {
         $deliveryExecution = $this->getCurrentDeliveryExecution();
         $deliveryService = $this->getServiceManager()->get(DeliveryService::CONFIG_ID);
         $executionState = $deliveryService->getState($deliveryExecution);
 
         // if the test taker is already authorized, straight forward to the execution
-        if (DeliveryService::STATE_AUTHORIZED == $executionState || DeliveryService::STATE_INPROGRESS == $executionState) {
-            return $this->forward('runDeliveryExecution');
+        // note: the authorized state is valid only if the security key has been set,
+        // if the test taker tries to directly access this page, the security key may not be initialized (i.e. just logged in)
+        if (DeliveryService::STATE_AUTHORIZED == $executionState && $this->hasSecurityKey()) {
+            $this->grantAuthorization();
+            return $this->redirect(_url('runDeliveryExecution', null, null, array('init' => true, 'deliveryExecution' => $deliveryExecution->getIdentifier())));
+        }
+
+        // from this page the test taker must wait for proctor authorization
+        $this->revokeAuthorization();
+
+        // if the test is in progress, first pause it to avoid inconsistent storage state
+        if (DeliveryService::STATE_INPROGRESS == $executionState) {
+            $deliveryService->pauseExecution($deliveryExecution);
         }
 
         // we need to change the state of the delivery execution
-        if (DeliveryService::STATE_INIT == $executionState || DeliveryService::STATE_PAUSED == $executionState) {
+        if (DeliveryService::STATE_TERMINATED != $executionState && DeliveryService::STATE_COMPLETED != $executionState) {
             $deliveryService->waitExecution($deliveryExecution);
             $executionState = $deliveryService->getState($deliveryExecution);
         }
@@ -131,32 +167,45 @@ class DeliveryServer extends \taoDelivery_actions_DeliveryServer
             $this->setView('DeliveryServer/layout.tpl', 'taoDelivery');
         } else {
             // inconsistent state
-            \common_Logger::i(get_called_class() . '::awaitingAuthorization(): cannot wait authorization for delivery execution ' . $deliveryExecution->getIdentifier() . ' with state ' . $executionState);
-            return $this->forward('index');
+            common_Logger::i(get_called_class() . '::awaitingAuthorization(): cannot wait authorization for delivery execution ' . $deliveryExecution->getIdentifier() . ' with state ' . $executionState);
+            return $this->redirect(_url('index'));
         }
     }
     
     /**
      * The action called to check if the requested delivery execution has been authorized by the proctor
      */
-    public function isAuthorized(){
-        
+    public function isAuthorized()
+    {
         $deliveryExecution = $this->getCurrentDeliveryExecution();
         $deliveryService = $this->getServiceManager()->get(DeliveryService::CONFIG_ID);
         $executionState = $deliveryService->getState($deliveryExecution);
 
-        $authorized = DeliveryService::STATE_AUTHORIZED == $executionState || DeliveryService::STATE_INPROGRESS == $executionState;
+        $authorized = false;
         $success = true;
         $message = null;
-
-        if (DeliveryService::STATE_TERMINATED == $executionState || DeliveryService::STATE_COMPLETED == $executionState) {
-            $success = false;
-            $message = __('This test has been terminated');
-        }
-
-        if (DeliveryService::STATE_PAUSED == $executionState) {
-            $success = false;
-            $message = __('This test has been suspended');
+        
+        // reacts to a few particular states
+        switch ($executionState) {
+            case DeliveryService::STATE_AUTHORIZED:
+                // note: the authorized state is valid only if the security key has been set,
+                // if the test taker tries to directly access this page, the security key may not be initialized (i.e. just logged in)
+                if ($this->hasSecurityKey()) {
+                    $this->grantAuthorization();
+                    $authorized = true;
+                }
+                break;
+            
+            case DeliveryService::STATE_TERMINATED:
+            case DeliveryService::STATE_COMPLETED:
+                $success = false;
+                $message = __('This test has been terminated');
+                break;
+                
+            case DeliveryService::STATE_PAUSED:
+                $success = false;
+                $message = __('This test has been suspended');
+                break;
         }
 
         $this->returnJson(array(
@@ -164,5 +213,60 @@ class DeliveryServer extends \taoDelivery_actions_DeliveryServer
             'success' => $success,
             'message' => $message
         ));
+    }
+
+    /**
+     * Checks if a security key has been set.
+     * @return bool
+     */
+    protected function hasSecurityKey()
+    {
+        return PHPSession::singleton()->hasAttribute(self::SECURE_KEY_NAME);
+    }
+    
+    /**
+     * Gets the current security key.
+     * Generates a new one if needed.
+     * @return string
+     */
+    protected function getSecurityKey()
+    {
+        if (!$this->hasSecurityKey()) {
+            $this->revokeAuthorization();
+        }
+        return PHPSession::singleton()->getAttribute(self::SECURE_KEY_NAME);
+    }
+
+    /**
+     * Grants the proctor authorization: sets the current security key into the access key.
+     */
+    protected function grantAuthorization()
+    {
+        $securityKey = $this->getSecurityKey();
+        common_Logger::i('Grant the proctor authorization, with security key: ' . $securityKey);
+        PHPSession::singleton()->setAttribute(self::ACCESS_KEY_NAME, $securityKey);
+    }
+
+    /**
+     * Revokes the proctor authorization: generates a new security key.
+     */
+    protected function revokeAuthorization()
+    {
+        $session = PHPSession::singleton();
+        $securityKey = uniqid();
+        common_Logger::i('Reset the proctor security key with value: ' . $securityKey);
+        $session->setAttribute(self::SECURE_KEY_NAME, $securityKey);
+        $session->setAttribute(self::ACCESS_KEY_NAME, null);
+    }
+
+    /**
+     * Checks the proctor authorization: checks if the value of the access key is the same as the security key.
+     * @return bool
+     */
+    protected function checkAuthorization()
+    {
+        $session = PHPSession::singleton();
+        return $session->hasAttribute(self::ACCESS_KEY_NAME) && 
+               $session->getAttribute(self::ACCESS_KEY_NAME) == $this->getSecurityKey();
     }
 }

--- a/controller/DeliveryServer.php
+++ b/controller/DeliveryServer.php
@@ -117,6 +117,9 @@ class DeliveryServer extends \taoDelivery_actions_DeliveryServer
             return $this->redirect(_url('awaitingAuthorization', null, null, array('deliveryExecution' => $deliveryExecution->getIdentifier())));
         }
 
+        // ensure the result server object is properly set to avoid test runner issue 
+        $this->ensureResultServerObject($deliveryExecution);
+
         // ok, the delivery execution can be processed
         parent::runDeliveryExecution();
     }
@@ -268,5 +271,23 @@ class DeliveryServer extends \taoDelivery_actions_DeliveryServer
         $session = PHPSession::singleton();
         return $session->hasAttribute(self::ACCESS_KEY_NAME) && 
                $session->getAttribute(self::ACCESS_KEY_NAME) == $this->getSecurityKey();
+    }
+
+    /**
+     * Ensures the result server object is properly set
+     * 
+     * @param \taoDelivery_models_classes_execution_DeliveryExecution $deliveryExecution
+     */
+    protected function ensureResultServerObject($deliveryExecution)
+    {
+        $session = PHPSession::singleton();
+        if (!$session->hasAttribute('resultServerObject') || !$session->getAttribute('resultServerObject')) {
+            $compiledDelivery = $deliveryExecution->getDelivery();
+            $resultServerUri = $compiledDelivery->getOnePropertyValue(new \core_kernel_classes_Property(TAO_DELIVERY_RESULTSERVER_PROP));
+            $resultServerObject = new \taoResultServer_models_classes_ResultServer($resultServerUri, array());
+
+            $session->setAttribute('resultServerUri', $resultServerUri->getUri());
+            $session->setAttribute('resultServerObject', array($resultServerUri->getUri() => $resultServerObject));
+        }
     }
 }

--- a/controller/DeliveryServer.php
+++ b/controller/DeliveryServer.php
@@ -114,7 +114,7 @@ class DeliveryServer extends \taoDelivery_actions_DeliveryServer
             // the test taker is not allowed to run the delivery
             // so we redirect him/her to the awaiting page
             common_Logger::i(get_called_class() . '::runDeliveryExecution(): try to run delivery without proctor authorization for delivery execution ' . $deliveryExecution->getIdentifier() . ' with state ' . $executionState);
-            return $this->redirect(_url('awaitingAuthorization', null, null, array('init' => true, 'deliveryExecution' => $deliveryExecution->getIdentifier())));
+            return $this->redirect(_url('awaitingAuthorization', null, null, array('deliveryExecution' => $deliveryExecution->getIdentifier())));
         }
 
         // ok, the delivery execution can be processed
@@ -135,7 +135,7 @@ class DeliveryServer extends \taoDelivery_actions_DeliveryServer
         // if the test taker tries to directly access this page, the security key may not be initialized (i.e. just logged in)
         if (DeliveryService::STATE_AUTHORIZED == $executionState && $this->hasSecurityKey()) {
             $this->grantAuthorization();
-            return $this->redirect(_url('runDeliveryExecution', null, null, array('init' => true, 'deliveryExecution' => $deliveryExecution->getIdentifier())));
+            return $this->redirect(_url('runDeliveryExecution', null, null, array('deliveryExecution' => $deliveryExecution->getIdentifier())));
         }
 
         // from this page the test taker must wait for proctor authorization

--- a/model/implementation/DeliveryService.php
+++ b/model/implementation/DeliveryService.php
@@ -405,7 +405,7 @@ class DeliveryService extends ConfigurableService
         $executionState = $this->getState($deliveryExecution);
         $result = false;
 
-        if (self::STATE_INIT == $executionState || self::STATE_PAUSED == $executionState) {
+        if (self::STATE_TERMINATED != $executionState && self::STATE_COMPLETED != $executionState) {
             $this->setProctoringState($deliveryExecution, self::STATE_AWAITING);
 
             $result = true;


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-1918

Add session stored values to check if the proctor authorization is valid for the current test taker's HTTP session.

If the test taker refreshes the page, he/she can continue to process the assessment. But if he/she logs off, or goes to the index page, he/she will have to wait for proctor authorization when trying to process the delivery again, even if the delivery has already been authorized and is in progress.

Without this patch, when the delivery is authorized, the test taker can can log off and log in, and then access the delivery without waiting for proctor authorization. The test taker can also return to the index page, and still process the delivery without proctor re-authorization.