### PR TITLE
using new assigned proctor properties

### DIFF
--- a/controller/TestCenterManager.php
+++ b/controller/TestCenterManager.php
@@ -22,6 +22,7 @@
 namespace oat\taoProctoring\controller;
 
 use oat\taoProctoring\model\TestCenterService;
+use oat\taoProctoring\model\ProctorManagementService;
 use oat\taoProctoring\model\EligibilityService;
 use oat\taoProctoring\helpers\DataTableHelper;
 
@@ -84,7 +85,7 @@ class TestCenterManager extends \tao_actions_SaSModule
         $administratorForm->setData('title', __('Assign administrator'));
         $this->setData('administratorForm', $administratorForm->render());
 
-        $proctorProperty = new \core_kernel_classes_Property(TestCenterService::PROPERTY_PROCTORS_URI);
+        $proctorProperty = new \core_kernel_classes_Property(ProctorManagementService::PROPERTY_ASSIGNED_PROCTOR_URI);
         $proctorForm = \tao_helpers_form_GenerisTreeForm::buildReverseTree($testCenter, $proctorProperty);
         $proctorForm->setData('title', __('Assign proctors'));
         $this->setData('proctorForm', $proctorForm->render());

--- a/model/ProctorManagementService.php
+++ b/model/ProctorManagementService.php
@@ -34,8 +34,6 @@ class ProctorManagementService extends tao_models_classes_ClassService
 {
     const CLASS_URI = 'http://www.tao.lu/Ontologies/TAO.rdf#User';
 
-    const PROPERTY_PROCTORS_URI = 'http://www.tao.lu/Ontologies/TAOTestCenter.rdf#proctor';
-
     const PROPERTY_ADMINISTRATOR_URI = 'http://www.tao.lu/Ontologies/TAOTestCenter.rdf#administrator';
 
     const PROPERTY_AUTHORIZED_PROCTOR_URI = 'http://www.tao.lu/Ontologies/TAOTestCenter.rdf#authorizedProctor';

--- a/model/TestCenterService.php
+++ b/model/TestCenterService.php
@@ -38,15 +38,14 @@ class TestCenterService extends tao_models_classes_ClassService
 
     const PROPERTY_MEMBERS_URI = 'http://www.tao.lu/Ontologies/TAOTestCenter.rdf#member';//deprecated
 
-    const PROPERTY_PROCTORS_URI = 'http://www.tao.lu/Ontologies/TAOTestCenter.rdf#proctor';
-
     const PROPERTY_DELIVERY_URI = 'http://www.tao.lu/Ontologies/TAOTestCenter.rdf#administers';//deprecated
 
     const PROPERTY_CHILDREN_URI = 'http://www.tao.lu/Ontologies/TAOTestCenter.rdf#children';
 
     const PROPERTY_ADMINISTRATOR_URI = 'http://www.tao.lu/Ontologies/TAOTestCenter.rdf#administrator';
 
-    const PROPERTY_AUTHORIZED_PROCTORS_URI = 'http://www.tao.lu/Ontologies/TAOTestCenter.rdf#authorizedProctor';
+    const PROPERTY_AUTHORIZED_PROCTOR_URI = 'http://www.tao.lu/Ontologies/TAOTestCenter.rdf#authorizedProctor';
+    
     /**
      * return the test center top level class
      *
@@ -67,8 +66,11 @@ class TestCenterService extends tao_models_classes_ClassService
      */
     public function getTestCentersByProctor(User $user) {
         $testCenters = array();
-        foreach ($user->getPropertyValues(self::PROPERTY_AUTHORIZED_PROCTORS_URI) as $id) {
-            $testCenters[] = new core_kernel_classes_Resource($id);
+        foreach ($user->getPropertyValues(self::PROPERTY_AUTHORIZED_PROCTOR_URI) as $testCenterUri) {
+            $testCenters[$testCenterUri] = new core_kernel_classes_Resource($testCenterUri);
+        }
+        foreach ($user->getPropertyValues(self::PROPERTY_ADMINISTRATOR_URI) as $testCenterUri) {
+            $testCenters[$testCenterUri] = new core_kernel_classes_Resource($testCenterUri);
         }
         return $testCenters;
     }

--- a/views/templates/layout.tpl
+++ b/views/templates/layout.tpl
@@ -27,7 +27,7 @@ use oat\tao\model\theme\Theme;
                     <div class="settings-menu">
                         <ul class="clearfix plain">
                             <li data-control="home">
-                                <a id="home" href="<?= _url('testCenters', 'TestCenter', 'taoProctoring') ?>">
+                                <a id="home" href="<?= _url('index', 'TestCenter', 'taoProctoring') ?>">
                                     <span class="icon-home"></span>
                                 </a>
                             </li>


### PR DESCRIPTION
This will connect the test center listing to the new authorized proctor property.
With this we can test the whole workflow, so this should allow :
* ACT admin (backoffice) create a test center, assign test center admin and proctors
* test site admin can access proctor management screen and see the assigned proctors
* test site admin can authorize/unauthorize the assigned proctors
* authorized proctor can now see their test center
* test site admin can create new proctor and the new proctor is visible among the assigned proctors tree in the ACT admin interface
