### PR TITLE
apply the filtering also on executions without an end time

### DIFF
--- a/helpers/TestCenterHelper.php
+++ b/helpers/TestCenterHelper.php
@@ -268,6 +268,9 @@ class TestCenterHelper
                     if ($finishTime && $periodStart && $periodStart > DateHelper::getTimeStamp($finishTime)) {
                         continue;
                     }
+                    if(!$finishTime && $periodStart && $periodEnd && ( DateHelper::getTimeStamp($startTime) > $periodEnd ||  DateHelper::getTimeStamp($startTime) < $periodStart )) {
+                        continue;
+                    }
                     if ($startTime && $periodEnd && $periodEnd < DateHelper::getTimeStamp($startTime)) {
                         continue;
                     }


### PR DESCRIPTION
Let some delivery executions opened/awaiting 
As a proctor, open the Activity report GUI and filter with a date in the future, all unterminated deliveries will stay listed.
The PR should fix that.