### PR TITLE
Add checking of delivery execution status

### DIFF
--- a/helpers/DeliveryHelper.php
+++ b/helpers/DeliveryHelper.php
@@ -490,7 +490,8 @@ class DeliveryHelper
                     }
                 }
 
-                $online = $testSessionConnectivityStatusService->isOnline($deliveryExecution->getIdentifier());
+                $online = $deliveryExecution->getState()->getUri() === DeliveryExecution::STATE_ACTIVE &&
+                          $testSessionConnectivityStatusService->isOnline($deliveryExecution->getIdentifier());
 
                 $delivery = $deliveryExecution->getDelivery();
                 $executions[] = array(


### PR DESCRIPTION
To reduce amount of queries to the DB and improve performance I added checking of connectivity status only for active delivery executions because there is no need to check this status for finished, paused or terminated executions.