### PR TITLE
Use the position in the section instead of the whole test

### DIFF
--- a/model/monitorCache/implementation/DeliveryMonitoringData.php
+++ b/model/monitorCache/implementation/DeliveryMonitoringData.php
@@ -202,38 +202,12 @@ class DeliveryMonitoringData implements DeliveryMonitoringDataInterface
         if ($session !== null) {
             if ($session->isRunning()) {
                 $route = $session->getRoute();
-                $routeItems = $route->getAllRouteItems();
-                $currentPosition = $route->getPosition();
                 $currentSection = $session->getCurrentAssessmentSection();
-                $currentSectionId = $currentSection->getIdentifier();
+                $sectionItems = $route->getRouteItemsByAssessmentSection($currentSection);
+                $currentItem = $route->current();
+                $positionInSection = array_search($currentItem, $sectionItems->getArrayCopy(true));
 
-                $sectionCount = 0;
-                $positionInSection = 0;
-                $offset = 0;
-                $offsetSection = 0;
-                $lastSection = null;
-
-                foreach ($routeItems as $routeItem) {
-                    $sections = $routeItem->getAssessmentSections();
-                    $sectionId = key(current($sections));
-
-                    if ($lastSection != $sectionId) {
-                        $offsetSection = 0;
-                        $lastSection = $sectionId;
-                    }
-
-                    if ($sectionId == $currentSectionId) {
-                        if ($offset == $currentPosition) {
-                            $positionInSection = $offsetSection;
-                        }
-                        $sectionCount ++;
-                    }
-
-                    $offset ++;
-                    $offsetSection ++;
-                }
-
-                $result =  __('%1$s - item %2$s/%3$s', $currentSection->getTitle(), $positionInSection+1, $sectionCount);
+                $result = __('%1$s - item %2$s/%3$s', $currentSection->getTitle(), $positionInSection + 1, count($sectionItems));
             } else {
                 $result = __('finished');
             }

--- a/model/monitorCache/implementation/DeliveryMonitoringData.php
+++ b/model/monitorCache/implementation/DeliveryMonitoringData.php
@@ -200,12 +200,40 @@ class DeliveryMonitoringData implements DeliveryMonitoringDataInterface
         $session = $this->getTestSession();
 
         if ($session !== null) {
-            $pos = $session->getRoute()->getPosition();
-            $count = $session->getRouteCount();
-
             if ($session->isRunning()) {
-                $section = $session->getCurrentAssessmentSection();
-                $result =  __('%1$s - item %2$s/%3$s', $section->getTitle(), $pos+1, $count);
+                $route = $session->getRoute();
+                $routeItems = $route->getAllRouteItems();
+                $currentPosition = $route->getPosition();
+                $currentSection = $session->getCurrentAssessmentSection();
+                $currentSectionId = $currentSection->getIdentifier();
+
+                $sectionCount = 0;
+                $positionInSection = 0;
+                $offset = 0;
+                $offsetSection = 0;
+                $lastSection = null;
+
+                foreach ($routeItems as $routeItem) {
+                    $sections = $routeItem->getAssessmentSections();
+                    $sectionId = key(current($sections));
+
+                    if ($lastSection != $sectionId) {
+                        $offsetSection = 0;
+                        $lastSection = $sectionId;
+                    }
+
+                    if ($sectionId == $currentSectionId) {
+                        if ($offset == $currentPosition) {
+                            $positionInSection = $offsetSection;
+                        }
+                        $sectionCount ++;
+                    }
+
+                    $offset ++;
+                    $offsetSection ++;
+                }
+
+                $result =  __('%1$s - item %2$s/%3$s', $currentSection->getTitle(), $positionInSection+1, $sectionCount);
             } else {
                 $result = __('finished');
             }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-2694

Build the assessment progress status from the current position inside the section rather than the position inside the whole test.