### PR TITLE
prevent checking testcenter for ghost execs

### DIFF
--- a/model/authorization/ProctorDeliveryAuthorizationService.php
+++ b/model/authorization/ProctorDeliveryAuthorizationService.php
@@ -50,14 +50,18 @@ class ProctorDeliveryAuthorizationService extends ConfigurableService  implement
     public function getAuthorizationProvider(DeliveryExecution $deliveryExecution, User $user)
     {
         $eligibilityService = EligibilityService::singleton();
-        $testCenter         = $eligibilityService->getTestCenter($deliveryExecution->getDelivery(), $user);
 
-        $eligibility = $eligibilityService->getEligibility($testCenter, $deliveryExecution->getDelivery());
+        if( $deliveryExecution->exists()){
+            $testCenter = $eligibilityService->getTestCenter($deliveryExecution->getDelivery(), $user);
 
-        if($eligibilityService->canByPassProctor($eligibility)){
-            return new DeliveryAuthorizationProvider();
+            if(!is_null($testCenter)){
+                $eligibility = $eligibilityService->getEligibility($testCenter, $deliveryExecution->getDelivery());
+
+                if($eligibilityService->canByPassProctor($eligibility)){
+                    return new DeliveryAuthorizationProvider();
+                }
+            }
         }
-
         return new ProctorAuthorizationProvider($deliveryExecution);
     }
 }


### PR DESCRIPTION
- remove a test center with active executions, then try to connect with a test takers who was assigned to the execution.