### PR TITLE
Move grid to separate container

### DIFF
--- a/views/templates/form_test_center.tpl
+++ b/views/templates/form_test_center.tpl
@@ -15,20 +15,18 @@ Template::inc('form_context.tpl', 'tao');
     </div>
 
 </div>
-
 <div class="data-container-wrapper flex-container-remainder">
+        <?=get_data('administratorForm')?>
 
-    <?=get_data('administratorForm')?>
+        <?=get_data('proctorForm')?>
 
-    <?=get_data('proctorForm')?>
-
-    <?=get_data('childrenForm')?>
-
-    <div class="eligible-deliveries" data-testcenter="<?=get_data('testCenter')?>">
+        <?=get_data('childrenForm')?>
+</div>
+<div class="grid-row">
+    <div class="col-12 eligible-deliveries" data-testcenter="<?=get_data('testCenter')?>">
         <div class="eligibility-table-container"></div>
         <div class="eligibility-editor-container"></div>
     </div>
-
 </div>
 
 <?php

--- a/views/templates/form_test_center.tpl
+++ b/views/templates/form_test_center.tpl
@@ -16,11 +16,11 @@ Template::inc('form_context.tpl', 'tao');
 
 </div>
 <div class="data-container-wrapper flex-container-remainder">
-        <?=get_data('administratorForm')?>
+    <?=get_data('administratorForm')?>
 
-        <?=get_data('proctorForm')?>
+    <?=get_data('proctorForm')?>
 
-        <?=get_data('childrenForm')?>
+    <?=get_data('childrenForm')?>
 </div>
 <div class="grid-row">
     <div class="col-12 eligible-deliveries" data-testcenter="<?=get_data('testCenter')?>">


### PR DESCRIPTION
If `Assign proctors` tree higher than `Define sub-centers`  tree then markup breaks down:
![elig](https://cloud.githubusercontent.com/assets/11025793/16812185/9afdd0ec-48f1-11e6-9adf-05ce17449577.png)
