### PR TITLE
Fix the undefined error message

### DIFF
--- a/views/js/controller/Delivery/index.js
+++ b/views/js/controller/Delivery/index.js
@@ -33,7 +33,7 @@ define([
     'taoProctoring/component/breadcrumbs',
     'tpl!taoProctoring/templates/delivery/listBoxActions',
     'tpl!taoProctoring/templates/delivery/listBoxStats'
-], function (_, $, __, helpers, loadingBar, listBox, encode, feedback, bulkActionPopup, cascadingComboBox, _status, breadcrumbsFactory, actionsTpl, statsTpl) {
+], function (_, $, __, helpers, loadingBar, listBoxFactory, encode, feedback, bulkActionPopup, cascadingComboBox, _status, breadcrumbsFactory, actionsTpl, statsTpl) {
     'use strict';
 
     /**
@@ -41,9 +41,6 @@ define([
      * @type {String}
      */
     var cssScope = '.delivery-index';
-
-    // the page is always loading data when starting
-    loadingBar.start();
 
     /**
      * Controls the ProctorDelivery index page
@@ -54,166 +51,205 @@ define([
         /**
          * Entry point of the page
          */
-        start : function start() {
+        start: function start() {
             var $container = $(cssScope);
-            var boxes = $container.data('list');
+            var list = $container.data('list');
+            var deliveries = format(list);
             var crumbs = $container.data('breadcrumbs');
             var categories = $container.data('categories');
             var testCenterId = $container.data('testcenter');
-            var list = listBox({
+            var serviceUrl = helpers._url('deliveries', 'Delivery', 'taoProctoring', {testCenter: testCenterId});
+            var listBox = listBoxFactory({
                 title: __("Sessions"),
                 textEmpty: __("No sessions available"),
                 textNumber: __("Available"),
                 textLoading: __("Loading"),
                 renderTo: $container.find('.content'),
                 replace: true,
-                list: format(boxes),
-                width:12,
+                list: list,
+                width: 12,
 
                 // discard the "all sessions" box from available count
-                countRenderer: function(count) {
+                countRenderer: function (count) {
                     return count - 1;
                 }
             });
-            var bc = breadcrumbsFactory($container, crumbs);
-            var serviceUrl = helpers._url('deliveries', 'Delivery', 'taoProctoring', {testCenter : testCenterId});
-            
-            function format(boxes){
-                
-                _.each(boxes, function(box){
 
-                    var props = box.properties;
+            // format each delivery descriptor to be displayed in a box, build a map of deliveries
+            function format(data) {
+                return _.transform(data, function (result, delivery) {
+                    var props = delivery.properties;
                     var tplData = {
-                        locked : box.stats.awaitingApproval,
-                        inProgress : box.stats.inProgress,
-                        paused : box.stats.paused
+                        locked: delivery.stats.awaitingApproval,
+                        inProgress: delivery.stats.inProgress,
+                        paused: delivery.stats.paused
                     };
 
-                    if(props && props.periodStart && props.periodEnd){
+                    if (props && props.periodStart && props.periodEnd) {
                         tplData.showProperties = true;
                         tplData.periodStart = props.periodStart;
                         tplData.periodEnd = props.periodEnd;
 
                         //add a special class for boxes that have more information to display
-                        box.cls = 'has-properties-displayed';
+                        delivery.cls = 'has-properties-displayed';
                     }
-                    box.html = actionsTpl({
-                        id : box.id
+                    delivery.html = actionsTpl({
+                        id: delivery.id
                     });
-                    box.content = statsTpl(tplData);
-                });
+                    delivery.content = statsTpl(tplData);
 
-                return boxes;
+                    result[delivery.id] = delivery;
+                }, {});
+            }
+
+            // get the label of a delivery from its ID
+            function getDeliveryLabel(id) {
+                return deliveries[id] && deliveries[id].label;
             }
 
             // update the index from a JSON array
-            function update(boxes) {
-                list.update(format(boxes));
+            function update(data) {
+                deliveries = format(data);
+                listBox.update(data);
                 loadingBar.stop();
             }
 
             // refresh the index
             function refresh() {
                 loadingBar.start();
-                list.setLoading(true);
+                listBox.setLoading(true);
 
                 $.ajax({
                     url: serviceUrl,
                     cache: false,
-                    dataType : 'json',
+                    dataType: 'json',
                     type: 'GET'
-                }).done(function(boxes) {
-                    update(boxes);
+                }).done(function (data) {
+                    update(data);
                 });
             }
-            
-            /**
-             * Exec 
-             * @param {String} actionName
-             * @param {String} actionTitle
-             * @param {Array} selection
-             * @param {Function} cb
-             * @returns {undefined}
-             */
-            function pause(deliveryId, selection){
-                
-                var allowed  = _.map(selection, function(data){
+
+            // request a pause fo the selected delivery executions
+            function pause(deliveryId, selection, deliveryExecutions) {
+
+                var allowed = _.map(selection, function (data) {
                     return {
-                        id : data.id,
-                        label : data.testTaker.firstName + ' ' + data.testTaker.lastName
+                        id: data.id,
+                        label: data.testTaker.firstName + ' ' + data.testTaker.lastName
                     };
                 });
-                
+
                 bulkActionPopup({
-                    renderTo : $container,
-                    actionName : __('Pause Session'),
-                    reason : true,
-                    resourceType : 'test taker',
+                    renderTo: $container,
+                    actionName: __('Pause Session'),
+                    reason: true,
+                    resourceType: 'test taker',
                     categoriesSelector: cascadingComboBox({
                         categoriesDefinitions: categories.pause.categoriesDefinitions,
                         categories: categories.pause.categories
                     }),
-                    allowedResources : allowed
-                }).on('ok', function(reason){
+                    allowedResources: allowed
+                }).on('ok', function (reason) {
                     //execute callback
                     $.ajax({
                         url: helpers._url('pauseExecutions', 'Delivery', 'taoProctoring'),
                         data: {
-                            delivery : deliveryId,
-                            testCenter : testCenterId,
+                            delivery: deliveryId,
+                            testCenter: testCenterId,
                             execution: _.pluck(selection, 'id'),
                             reason: reason
                         },
-                        dataType : 'json',
+                        dataType: 'json',
                         type: 'POST',
-                        error: function() {
+                        error: function () {
                             loadingBar.stop();
                         }
-                    }).done(function(response) {
+                    }).done(function (response) {
+                        var messageContext, unprocessed;
+
                         loadingBar.stop();
+
                         if (response && response.success) {
                             feedback().success('Selected deliveries successfully paused');
                             refresh();
                         } else {
-                            feedback().warning(__('Something went wrong ...') + '<br>' + encode.html(response.error), {encodeHtml: false});
+                            messageContext = '';
+                            if (response) {
+                                unprocessed = {};
+                                _.forEach(response.unprocessed, function (id) {
+                                    var execution = deliveryExecutions[id];
+                                    var uri = execution && execution.delivery && execution.delivery.uri;
+                                    if (uri) {
+                                        unprocessed[uri] = (unprocessed[uri] || 0) + 1;
+                                    }
+                                });
+
+                                unprocessed = _.map(unprocessed, function (count, uri) {
+                                    if (count > 1) {
+                                        return __('%d sessions of the delivery %s have not been paused', count, getDeliveryLabel(uri));
+                                    }
+                                    return __('A session of the delivery %s have not been paused', getDeliveryLabel(uri));
+                                });
+
+                                if (unprocessed.length) {
+                                    messageContext += '<br>' + unprocessed.join('<br>');
+                                }
+                                if (response.error) {
+                                    messageContext += '<br>' + encode.html(response.error);
+                                }
+                            }
+                            feedback().warning(__('Something went wrong ...') + '<br>' + messageContext, {encodeHtml: false});
                         }
                     });
                 });
             }
-            
-            $container.on('click', '.pause', function(e){
-                
+
+            breadcrumbsFactory($container, crumbs);
+
+            $container.on('click', '.pause', function (e) {
+
                 var deliveryId = $(this).data('delivery');
-                var pauseUrl = (deliveryId === 'all') ? 
-                    helpers._url('allDeliveriesExecutions', 'Delivery', 'taoProctoring', {testCenter : testCenterId}) :
-                    helpers._url('deliveryExecutions', 'Delivery', 'taoProctoring', {delivery : deliveryId, testCenter : testCenterId});
-                
+                var pauseUrl = (deliveryId === 'all') ?
+                    helpers._url('allDeliveriesExecutions', 'Delivery', 'taoProctoring', {testCenter: testCenterId}) :
+                    helpers._url('deliveryExecutions', 'Delivery', 'taoProctoring', {
+                        delivery: deliveryId,
+                        testCenter: testCenterId
+                    });
+
                 //prevent clicking the parent link that goes to the monitoring screen
                 e.stopPropagation();
                 e.preventDefault();
-                
+
                 //get list of all test taker for the selected delivery
-                $.get(pauseUrl, function(res){
-                    if(_.isPlainObject(res) && _.isArray(res.data)){
-                        var inProgressExecs = _.filter(res.data, function(data){
+                $.get(pauseUrl, function (res) {
+                    var deliveryExecutions = {};
+                    var inProgressExecs;
+
+                    if (_.isPlainObject(res) && _.isArray(res.data)) {
+                        inProgressExecs = _.filter(res.data, function (data) {
+                            deliveryExecutions[data.id] = data;
                             return (data.state && data.state.status === _status.getStatus('inprogress').code);
                         });
-                        if(inProgressExecs.length){
-                            pause(deliveryId, inProgressExecs);
-                        }else{
+
+                        if (inProgressExecs.length) {
+                            pause(deliveryId, inProgressExecs, deliveryExecutions);
+                        } else {
                             feedback().info(__('There is no delivery in progress'));
                         }
                     }
                 });
             });
-            
-            if (!boxes) {
+
+            if (!list) {
                 refresh();
             } else {
                 loadingBar.stop();
             }
         }
     };
+
+    // the page is always loading data when starting
+    loadingBar.start();
 
     return taoProctoringCtlr;
 });


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-2823

Requires: https://github.com/oat-sa/extension-tao-proctoring/pull/180

When trying to pause sessions from the monitoring index, if an error occurs the displayed message contains "undefined".

To easily reproduce the issue you need some unrecoverable blocked delivery executions. Otherwise you can fake an error in the controller: https://github.com/oat-sa/extension-tao-proctoring/blob/develop/controller/Delivery.php#L487

Added some refactoring to comply to ESLint rules.