### PR TITLE
change reason for terminated assessments

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -25,7 +25,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '3.5.2',
+    'version' => '3.5.3',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=4.5.0',

--- a/scripts/TerminatePausedAssessment.php
+++ b/scripts/TerminatePausedAssessment.php
@@ -107,7 +107,7 @@ class TerminatePausedAssessment implements Action, ServiceLocatorAwareInterface
             $deliveryExecution,
             [
                 'reasons' => ['category' => 'system'],
-                'comment' => __('Terminated due to timeout.'),
+                'comment' => __('Terminated by the system due to timeout.'),
             ]
         );
         $this->addReport(Report::TYPE_INFO, "Delivery execution {$deliveryExecution->getUri()} has been terminated.");

--- a/scripts/TerminatePausedAssessment.php
+++ b/scripts/TerminatePausedAssessment.php
@@ -106,7 +106,7 @@ class TerminatePausedAssessment implements Action, ServiceLocatorAwareInterface
         $deliveryExecutionStateService->terminateExecution(
             $deliveryExecution,
             [
-                'reasons' => ['category' => 'system '],
+                'reasons' => ['category' => 'system'],
                 'comment' => __('Terminated due to timeout.'),
             ]
         );

--- a/scripts/TerminatePausedAssessment.php
+++ b/scripts/TerminatePausedAssessment.php
@@ -105,7 +105,10 @@ class TerminatePausedAssessment implements Action, ServiceLocatorAwareInterface
         $deliveryExecutionStateService = ServiceManager::getServiceManager()->get(DeliveryExecutionStateService::SERVICE_ID);
         $deliveryExecutionStateService->terminateExecution(
             $deliveryExecution,
-            ['reasons' => 'Paused delivery execution was expired', 'comment' => '']
+            [
+                'reasons' => ['category' => 'system '],
+                'comment' => __('Terminated due to timeout.'),
+            ]
         );
         $this->addReport(Report::TYPE_INFO, "Delivery execution {$deliveryExecution->getUri()} has been terminated.");
     }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -470,7 +470,7 @@ class Updater extends common_ext_ExtensionUpdater {
             $this->setVersion('3.4.1');
         }
 
-        $this->skip('3.4.1','3.5.2');
+        $this->skip('3.4.1','3.5.3');
     }
 
     private function refreshMonitoringData()


### PR DESCRIPTION
Reason should be the same as proctor events have (in accordance with ODS documentation). 