### PR TITLE
use select request instead of fetching schema

### DIFF
--- a/config/default/DeliveryMonitoring.conf.php
+++ b/config/default/DeliveryMonitoring.conf.php
@@ -1,5 +1,6 @@
 <?php
 use oat\taoProctoring\model\monitorCache\implementation\MonitorCacheService;
+use oat\taoProctoring\model\monitorCache\implementation\DeliveryMonitoringService;
 /**
  * Default monitoring cache service
  */

--- a/config/default/DeliveryMonitoring.conf.php
+++ b/config/default/DeliveryMonitoring.conf.php
@@ -4,5 +4,14 @@ use oat\taoProctoring\model\monitorCache\implementation\MonitorCacheService;
  * Default monitoring cache service
  */
 return new MonitorCacheService(array(
-    MonitorCacheService::OPTION_PERSISTENCE => 'default'
+    MonitorCacheService::OPTION_PERSISTENCE => 'default',
+    MonitorCacheService::OPTION_PRIMARY_COLUMNS => [
+        DeliveryMonitoringService::COLUMN_DELIVERY_EXECUTION_ID,
+        DeliveryMonitoringService::COLUMN_STATUS,
+        DeliveryMonitoringService::COLUMN_CURRENT_ASSESSMENT_ITEM,
+        DeliveryMonitoringService::COLUMN_TEST_TAKER,
+        DeliveryMonitoringService::COLUMN_AUTHORIZED_BY,
+        DeliveryMonitoringService::COLUMN_START_TIME,
+        DeliveryMonitoringService::COLUMN_END_TIME,
+    ]
 ));

--- a/manifest.php
+++ b/manifest.php
@@ -25,7 +25,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '3.6.3',
+    'version' => '3.6.4',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=4.5.0',

--- a/model/monitorCache/implementation/DeliveryMonitoringService.php
+++ b/model/monitorCache/implementation/DeliveryMonitoringService.php
@@ -61,6 +61,8 @@ class DeliveryMonitoringService extends ConfigurableService implements DeliveryM
 {
     const OPTION_PERSISTENCE = 'persistence';
 
+    const OPTION_PRIMARY_COLUMNS = 'primary_columns';
+
     const TABLE_NAME = 'delivery_monitoring';
 
     const COLUMN_ID = 'id';
@@ -87,11 +89,6 @@ class DeliveryMonitoringService extends ConfigurableService implements DeliveryM
     const DEFAULT_SORT_ORDER = 'DESC';
 
     protected $joins = [];
-
-    /**
-     * @var array
-     */
-    protected $primaryTableColumns;
 
     /**
      * @param DeliveryExecution $deliveryExecution
@@ -439,19 +436,7 @@ class DeliveryMonitoringService extends ConfigurableService implements DeliveryM
      */
     protected function getPrimaryColumns()
     {
-        if ($this->primaryTableColumns === null) {
-            $stmt = $this->getPersistence()->query('select * from ' . self::TABLE_NAME . ' limit 1');
-            $data = $stmt->fetchAll(\PDO::FETCH_ASSOC);
-            if (empty($data)) {//table is empty yet, fallback to use db schema
-                $schemaManager = $this->getPersistence()->getDriver()->getSchemaManager();
-                $schema = $schemaManager->createSchema();
-                $this->primaryTableColumns = array_keys($schema->getTable(self::TABLE_NAME)->getColumns());
-            } else {
-                $this->primaryTableColumns = array_keys($data[0]);
-            }
-
-        }
-        return $this->primaryTableColumns;
+        return $this->getOption(self::OPTION_PRIMARY_COLUMNS);
     }
 
     /**

--- a/model/monitorCache/implementation/DeliveryMonitoringService.php
+++ b/model/monitorCache/implementation/DeliveryMonitoringService.php
@@ -440,9 +440,16 @@ class DeliveryMonitoringService extends ConfigurableService implements DeliveryM
     protected function getPrimaryColumns()
     {
         if ($this->primaryTableColumns === null) {
-            $schemaManager = $this->getPersistence()->getDriver()->getSchemaManager();
-            $schema = $schemaManager->createSchema();
-            $this->primaryTableColumns = array_keys($schema->getTable(self::TABLE_NAME)->getColumns());
+            $stmt = $this->getPersistence()->query('select * from ' . self::TABLE_NAME . ' limit 1');
+            $data = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+            if (empty($data)) {//table is empty yet, fallback to use db schema
+                $schemaManager = $this->getPersistence()->getDriver()->getSchemaManager();
+                $schema = $schemaManager->createSchema();
+                $this->primaryTableColumns = array_keys($schema->getTable(self::TABLE_NAME)->getColumns());
+            } else {
+                $this->primaryTableColumns = array_keys($data[0]);
+            }
+
         }
         return $this->primaryTableColumns;
     }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -470,7 +470,7 @@ class Updater extends common_ext_ExtensionUpdater {
             $this->setVersion('3.4.1');
         }
 
-        $this->skip('3.4.1','3.6.3');
+        $this->skip('3.4.1','3.6.4');
     }
 
     private function refreshMonitoringData()

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -470,7 +470,25 @@ class Updater extends common_ext_ExtensionUpdater {
             $this->setVersion('3.4.1');
         }
 
-        $this->skip('3.4.1','3.6.4');
+        $this->skip('3.4.1','3.6.3');
+
+        if ($this->isVersion('3.6.3')) {
+            $deliveryMonitoringService = $this->getServiceManager()->get(DeliveryMonitoringService::CONFIG_ID);
+            $deliveryMonitoringService->setOption(
+                DeliveryMonitoringService::OPTION_PRIMARY_COLUMNS,
+                [
+                    DeliveryMonitoringService::COLUMN_DELIVERY_EXECUTION_ID,
+                    DeliveryMonitoringService::COLUMN_STATUS,
+                    DeliveryMonitoringService::COLUMN_CURRENT_ASSESSMENT_ITEM,
+                    DeliveryMonitoringService::COLUMN_TEST_TAKER,
+                    DeliveryMonitoringService::COLUMN_AUTHORIZED_BY,
+                    DeliveryMonitoringService::COLUMN_START_TIME,
+                    DeliveryMonitoringService::COLUMN_END_TIME,
+                ]
+            );
+            $this->getServiceManager()->register(DeliveryMonitoringService::CONFIG_ID, $deliveryMonitoringService);
+            $this->setVersion('3.6.4');
+        }
     }
 
     private function refreshMonitoringData()


### PR DESCRIPTION
I found that getting schema takes very long time. After this change I got significant accelerations for such requests as heartbeat, move (next, prev, skip), submitting item data and other requests where delivery monitoring storage is used. 
For example I got 50% acceleration for heartbeat call (189ms vs 361ms).