### PR TITLE
Fixed termination of expired deliveries from KV storage

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -25,7 +25,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '3.6.8',
+    'version' => '3.6.9',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=4.5.0',

--- a/model/implementation/TestSessionService.php
+++ b/model/implementation/TestSessionService.php
@@ -134,7 +134,7 @@ class TestSessionService extends ConfigurableService
         if (!isset($this->cache[$deliveryExecution->getIdentifier()]['expired'])) {
             $deliveryExecutionStateService = ServiceManager::getServiceManager()->get(DeliveryExecutionStateService::SERVICE_ID);
             $executionState = $deliveryExecutionStateService->getState($deliveryExecution);
-            if (!in_array($executionState, [DeliveryExecutionState::STATE_PAUSED, DeliveryExecutionState::STATE_ACTIVE]) ||
+            if (!in_array($executionState, $this->getExpirableStates()) ||
                 !$lastTestTakersEvent = $this->getLastTestTakersEvent($deliveryExecution)) {
                 return $this->cache[$deliveryExecution->getIdentifier()]['expired'] = false;
             }
@@ -187,6 +187,14 @@ class TestSessionService extends ConfigurableService
         }
 
         return $lastTestTakersEvent;
+    }
+
+    /**
+     * @return array
+     */
+    public function getExpirableStates()
+    {
+        return [DeliveryExecutionState::STATE_PAUSED, DeliveryExecutionState::STATE_ACTIVE];
     }
 
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -505,7 +505,7 @@ class Updater extends common_ext_ExtensionUpdater {
 
             $this->setVersion('3.6.6');
         }
-        $this->skip('3.6.6', '3.6.8');
+        $this->skip('3.6.6', '3.6.9');
 
     }
 


### PR DESCRIPTION
Termination script was incompatible with KV storage engine.
This workaround prevented from changes in the way we are storing executions in Redis.
