### PR TITLE
All executions retrieved for testtaker from KV storage

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -25,11 +25,11 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '3.6.8',
+    'version' => '3.6.9',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=4.5.0',
-        'taoDelivery' => '>=4.0.0',
+        'taoDelivery' => '>=4.4.1',
         'taoDeliveryRdf' => '>=1.0',
         'taoTestTaker' => '>=2.6.0',
         'taoQtiTest' => '>=5.10.1',
@@ -61,6 +61,7 @@ return array(
             'oat\\taoProctoring\\scripts\\install\\RegisterAssignmentService',
             'oat\\taoProctoring\\scripts\\install\\RegisterDeliveryServerService',
             'oat\\taoProctoring\\scripts\\install\\RegisterSessionStateListener',
+            'oat\\taoProctoring\\scripts\\install\\AdjustKVExecutionPersistenceService',
             RegisterAuthProvider::class
         ),
         'rdf' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -507,6 +507,19 @@ class Updater extends common_ext_ExtensionUpdater {
         }
         $this->skip('3.6.6', '3.6.8');
 
+        if ($this->isVersion('3.6.8')) {
+            $ext = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoDelivery');
+
+            $i = $ext->getConfig(\taoDelivery_models_classes_execution_ServiceProxy::CONFIG_KEY);
+            if ($i instanceof \taoDelivery_models_classes_execution_KeyValueService) {
+                $i->setOption(\taoDelivery_models_classes_execution_KeyValueService::OPTION_EXECUTION_STATE_INTERFACE,
+                    \oat\taoProctoring\model\execution\DeliveryExecution::class);
+
+                $ext->setConfig(\taoDelivery_models_classes_execution_ServiceProxy::CONFIG_KEY, $i);
+            }
+
+            $this->setVersion('3.6.9');
+        }
     }
 
     private function refreshMonitoringData()


### PR DESCRIPTION
depends on https://github.com/oat-sa/extension-tao-delivery/pull/195