### PR TITLE
pause delivery execution after initialization

### DIFF
--- a/controller/DeliveryServer.php
+++ b/controller/DeliveryServer.php
@@ -186,4 +186,13 @@ class DeliveryServer extends DefaultDeliveryServer
         }
     }
 
+    /**
+     * @inheritdoc
+     */
+    protected function _initDeliveryExecution()
+    {
+        $deliveryExecution = parent::_initDeliveryExecution();
+        $deliveryExecution->setState(DeliveryExecutionState::STATE_PAUSED);
+        return $deliveryExecution;
+    }
 }

--- a/manifest.php
+++ b/manifest.php
@@ -25,7 +25,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '3.6.14',
+    'version' => '3.6.15',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=4.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -505,7 +505,7 @@ class Updater extends common_ext_ExtensionUpdater {
 
             $this->setVersion('3.6.6');
         }
-        $this->skip('3.6.6', '3.6.14');
+        $this->skip('3.6.6', '3.6.15');
 
     }
 


### PR DESCRIPTION
During initialization of delivery execution it's state is set to `active`
https://github.com/oat-sa/extension-tao-delivery/blob/master/models/classes/execution/class.OntologyService.php#L104
and before it's state changed to `awaiting` active executions pauses here:
https://github.com/oat-sa/extension-tao-proctoring/blob/master/controller/DeliveryServer.php#L110

It causes redundant pause event in the ODS before the first proctor's authorization.