### PR TITLE
Feature/tao 3625 framed prohibited

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -26,7 +26,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '3.16.0',
+    'version' => '3.17.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=7.23.0',

--- a/model/implementation/TestSessionHistoryService.php
+++ b/model/implementation/TestSessionHistoryService.php
@@ -51,6 +51,7 @@ class TestSessionHistoryService extends ConfigurableService implements TestSessi
         'test_terminate',
         'test_irregularity',
         'pause',
+        'framed-prohibited',
         'focus-loss-prohibited',
         'leave-fullscreen-prohibited',
         'pause-on-disconnect',

--- a/model/implementation/TestSessionHistoryService.php
+++ b/model/implementation/TestSessionHistoryService.php
@@ -51,7 +51,7 @@ class TestSessionHistoryService extends ConfigurableService implements TestSessi
         'test_terminate',
         'test_irregularity',
         'pause',
-        'framed-prohibited',
+        'unsecured-launch-prohibited',
         'focus-loss-prohibited',
         'leave-fullscreen-prohibited',
         'pause-on-disconnect',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -656,6 +656,8 @@ class Updater extends common_ext_ExtensionUpdater
             OntologyUpdater::syncModels();
             $this->setVersion('3.16.0');
         }
+
+        $this->skip('3.16.0', '3.17.0');
     }
 
     private function refreshMonitoringData()


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3625

Requires: https://github.com/oat-sa/extension-tao-act/pull/449

Just display the event in the history (`unsecured-launch-prohibited`).
