### PR TITLE
Fix/tao 3788 test taker time

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '4.5.2',
+    'version' => '4.5.3',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=7.66.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -169,6 +169,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('4.4.0');
         }
 
-        $this->skip('4.4.0', '4.5.2');
+        $this->skip('4.4.0', '4.5.3');
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3788

Use the right time target when updating the cache of the delivery execution with the remaining time.