### PR TITLE
Fix/delivery column

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '4.10.5',
+    'version' => '4.10.6',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=7.81.1',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -220,6 +220,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('4.9.1');
         }
 
-        $this->skip('4.9.1', '4.10.5');
+        $this->skip('4.9.1', '4.10.6');
     }
 }

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -38,7 +38,6 @@ define([
     'taoProctoring/component/extraTime/encoder',
     'taoProctoring/helper/status',
     'tpl!taoProctoring/templates/delivery/monitoring',
-    'tpl!taoProctoring/templates/delivery/deliveryLink',
     'tpl!taoProctoring/templates/delivery/statusFilter',
     'ui/datatable',
     'jqueryui',
@@ -63,7 +62,6 @@ define([
     encodeExtraTime,
     _status,
     monitoringTpl,
-    deliveryLinkTpl,
     statusFilterTpl
 ) {
     'use strict';
@@ -82,7 +80,6 @@ define([
     var serviceUrl = urlHelper.route('monitor', 'Monitor', 'taoProctoring');
     var executionsUrl = urlHelper.route('deliveryExecutions', 'Monitor', 'taoProctoring');
     var historyUrl = urlHelper.route('index', 'Reporting', 'taoProctoring');
-    var deliveryUrl = urlHelper.route('monitoring', 'Delivery', 'taoProctoring');
 
     /**
      * The extra time unit: by default in minutes
@@ -663,8 +660,7 @@ define([
                         transform: function(value, row) {
                             var delivery = row && row.delivery;
                             if (delivery) {
-                                delivery.url = urlHelper.build(deliveryUrl, {delivery : delivery.uri});
-                                value = deliveryLinkTpl(delivery);
+                                value = delivery.label;
                             }
                             return value;
                         }


### PR DESCRIPTION
Remove the link from the delivery name column. This link was using the route of the old version of the proctoring. Moreover, this link cannot work in LTI mode.