### PR TITLE
Feature/tao 3942 pause message

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,6 +29,7 @@ use oat\taoProctoring\scripts\install\RegisterDeliveryServerService;
 use oat\taoProctoring\scripts\install\RegisterProctoringEntryPoint;
 use oat\taoProctoring\scripts\install\RegisterProctoringLog;
 use oat\taoProctoring\scripts\install\RegisterReasonCategoryService;
+use oat\taoProctoring\scripts\install\RegisterRunnerMessageService;
 use oat\taoProctoring\scripts\install\RegisterServices;
 use oat\taoProctoring\scripts\install\SetupDeliveryMonitoring;
 use oat\taoProctoring\scripts\install\SetupProctoringEventListeners;
@@ -38,14 +39,14 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '4.10.9',
+    'version' => '4.11.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=7.81.1',
         'taoDelivery' => '>=4.7.0',
         'taoDeliveryRdf' => '>=1.0',
         'taoTestTaker' => '>=2.6.0',
-        'taoQtiTest' => '>=5.38.0',
+        'taoQtiTest' => '>=6.18.0',
         'taoOutcomeUi' => '>=2.6.6',
         'generis' => '>=3.13.2',
     ),
@@ -70,7 +71,8 @@ return array(
             RegisterAuthProvider::class,
             RegisterServices::class,
             RegisterBreadcrumbsServices::class,
-            RegisterReasonCategoryService::class
+            RegisterReasonCategoryService::class,
+            RegisterRunnerMessageService::class,
         ),
         'rdf' => array(
             __DIR__.DIRECTORY_SEPARATOR.'scripts'.DIRECTORY_SEPARATOR.'install'.DIRECTORY_SEPARATOR.'proctoring.rdf'

--- a/model/implementation/TestRunnerMessageService.php
+++ b/model/implementation/TestRunnerMessageService.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ *
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+
+namespace oat\taoProctoring\model\implementation;
+
+use oat\taoProctoring\model\ProctorService;
+use oat\taoQtiTest\models\runner\QtiRunnerMessageService;
+use qtism\runtime\tests\AssessmentTestSession;
+
+/**
+ * Class QtiRunnerMessageService
+ * 
+ * Defines a service that will provide messages for the test runner
+ * 
+ * @package oat\taoQtiTest\models
+ */
+class TestRunnerMessageService extends QtiRunnerMessageService
+{
+    protected function isProctorAction(AssessmentTestSession $testSession)
+    {
+        $userRoles = \common_session_SessionManager::getSession()->getUserRoles();
+        return in_array(ProctorService::ROLE_PROCTOR, $userRoles);
+    }
+    
+    /**
+     * Gets a message about the paused status of the assessment
+     * @param AssessmentTestSession $testSession
+     * @return string
+     */
+    protected function getPausedStateMessage(AssessmentTestSession $testSession)
+    {
+        if ($this->isProctorAction($testSession)) {
+            return __('The assessment has been suspended. To resume your assessment, please relaunch it and contact your proctor if required.');
+        }
+        
+        return __('The assessment has been suspended. To resume your assessment, please relaunch it.');
+    }
+
+    /**
+     * Gets a message about the terminated status of the assessment
+     * @param AssessmentTestSession $testSession
+     * @return string
+     */
+    protected function getTerminatedStateMessage(AssessmentTestSession $testSession)
+    {
+        if ($this->isProctorAction($testSession)) {
+            return __('The assessment has been terminated. You cannot interact with it anymore. Please contact your proctor if required.');
+        }
+        
+        return __('The assessment has been terminated. You cannot interact with it anymore.');
+    }
+}

--- a/model/implementation/TestRunnerMessageService.php
+++ b/model/implementation/TestRunnerMessageService.php
@@ -29,9 +29,9 @@ use qtism\runtime\tests\AssessmentTestSession;
 
 /**
  * Class QtiRunnerMessageService
- * 
+ *
  * Defines a service that will provide messages for the test runner
- * 
+ *
  * @package oat\taoQtiTest\models
  */
 class TestRunnerMessageService extends QtiRunnerMessageService
@@ -41,7 +41,27 @@ class TestRunnerMessageService extends QtiRunnerMessageService
         $userRoles = \common_session_SessionManager::getSession()->getUserRoles();
         return in_array(ProctorService::ROLE_PROCTOR, $userRoles);
     }
-    
+
+    /**
+     * Gets a message about the paused status of the assessment when a proctor is the sender
+     * @param AssessmentTestSession $testSession
+     * @return string
+     */
+    protected function getProctorPausedStateMessage(AssessmentTestSession $testSession)
+    {
+        return __('The assessment has been suspended. To resume your assessment, please relaunch it and contact your proctor if required.');
+    }
+
+    /**
+     * Gets a message about the terminated status of the assessment when a proctor is the sender
+     * @param AssessmentTestSession $testSession
+     * @return string
+     */
+    protected function getProctorTerminatedStateMessage(AssessmentTestSession $testSession)
+    {
+        return __('The assessment has been terminated. You cannot interact with it anymore. Please contact your proctor if required.');
+    }
+
     /**
      * Gets a message about the paused status of the assessment
      * @param AssessmentTestSession $testSession
@@ -50,9 +70,9 @@ class TestRunnerMessageService extends QtiRunnerMessageService
     protected function getPausedStateMessage(AssessmentTestSession $testSession)
     {
         if ($this->isProctorAction($testSession)) {
-            return __('The assessment has been suspended. To resume your assessment, please relaunch it and contact your proctor if required.');
+            return $this->getProctorPausedStateMessage($testSession);
         }
-        
+
         return __('The assessment has been suspended. To resume your assessment, please relaunch it.');
     }
 
@@ -64,9 +84,9 @@ class TestRunnerMessageService extends QtiRunnerMessageService
     protected function getTerminatedStateMessage(AssessmentTestSession $testSession)
     {
         if ($this->isProctorAction($testSession)) {
-            return __('The assessment has been terminated. You cannot interact with it anymore. Please contact your proctor if required.');
+            return $this->getProctorTerminatedStateMessage($testSession);
         }
-        
+
         return __('The assessment has been terminated. You cannot interact with it anymore.');
     }
 }

--- a/model/implementation/TestSessionService.php
+++ b/model/implementation/TestSessionService.php
@@ -23,104 +23,23 @@ namespace oat\taoProctoring\model\implementation;
 use DateInterval;
 use DateTimeImmutable;
 use oat\oatbox\service\ServiceManager;
-use oat\taoDelivery\model\AssignmentService;
-use oat\taoProctoring\model\deliveryLog\DeliveryLog;
-use oat\taoQtiTest\models\runner\session\UserUriAware;
-use qtism\runtime\storage\binary\BinaryAssessmentTestSeeker;
-use qtism\runtime\tests\AssessmentTestSession;
 use oat\taoDelivery\model\execution\DeliveryExecution;
+use oat\taoProctoring\model\deliveryLog\DeliveryLog;
 use oat\taoProctoring\model\execution\DeliveryExecution as DeliveryExecutionState;
-use \oat\oatbox\service\ConfigurableService;
+use oat\taoQtiTest\models\TestSessionService as QtiTestSessionService;
 
 /**
  * Interface TestSessionService
  * @package oat\taoProctoring\model
  * @author Aleh Hutnikau <hutnikau@1pt.com>
  */
-class TestSessionService extends ConfigurableService
+class TestSessionService extends QtiTestSessionService
 {
     const SERVICE_ID = 'taoProctoring/TestSessionService';
-
-    /** @var array cache to store session instances */
-    protected $cache = [];
 
     public static function singleton()
     {
         return ServiceManager::getServiceManager()->get(TestSessionService::SERVICE_ID);
-    }
-
-    /**
-     * Gets the test session for a particular deliveryExecution
-     *
-     * @param DeliveryExecution $deliveryExecution
-     * @return \qtism\runtime\tests\AssessmentTestSession
-     * @throws \common_exception_Error
-     * @throws \common_exception_MissingParameter
-     */
-    public function getTestSession(DeliveryExecution $deliveryExecution)
-    {
-        if (!isset($this->cache[$deliveryExecution->getIdentifier()]['session'])) {
-            $resultServer = \taoResultServer_models_classes_ResultServerStateFull::singleton();
-
-            $compiledDelivery = $deliveryExecution->getDelivery();
-            $inputParameters = $this->getRuntimeInputParameters($deliveryExecution);
-
-            $testDefinition = \taoQtiTest_helpers_Utils::getTestDefinition($inputParameters['QtiTestCompilation']);
-            $testResource = new \core_kernel_classes_Resource($inputParameters['QtiTestDefinition']);
-
-            $sessionManager = new \taoQtiTest_helpers_SessionManager($resultServer, $testResource);
-
-            $userId = $deliveryExecution->getUserIdentifier();
-            $qtiStorage = new \taoQtiTest_helpers_TestSessionStorage(
-                $sessionManager,
-                new BinaryAssessmentTestSeeker($testDefinition), $userId
-            );
-
-            $sessionId = $deliveryExecution->getIdentifier();
-
-            if ($qtiStorage->exists($sessionId)) {
-                $session = $qtiStorage->retrieve($testDefinition, $sessionId);
-                if ($session instanceof UserUriAware) {
-                    $session->setUserUri($userId);
-                }
-
-                $resultServerUri = $compiledDelivery->getOnePropertyValue(new \core_kernel_classes_Property(TAO_DELIVERY_RESULTSERVER_PROP));
-                $resultServerObject = new \taoResultServer_models_classes_ResultServer($resultServerUri, array());
-                $resultServer->setValue('resultServerUri', $resultServerUri->getUri());
-                $resultServer->setValue('resultServerObject', array($resultServerUri->getUri() => $resultServerObject));
-                $resultServer->setValue('resultServer_deliveryResultIdentifier', $deliveryExecution->getIdentifier());
-            } else {
-                $session = null;
-            }
-
-            $this->cache[$deliveryExecution->getIdentifier()] = [
-                'session' => $session,
-                'storage' => $qtiStorage
-            ];
-        }
-
-        return $this->cache[$deliveryExecution->getIdentifier()]['session'];
-    }
-
-    /**
-     *
-     * @param DeliveryExecution $deliveryExecution
-     * @return array
-     * Example:
-     * <pre>
-     * array(
-     *   'QtiTestCompilation' => 'http://sample/first.rdf#i14369768868163155-|http://sample/first.rdf#i1436976886612156+',
-     *   'QtiTestDefinition' => 'http://sample/first.rdf#i14369752345581135'
-     * )
-     * </pre>
-     */
-    public function getRuntimeInputParameters(DeliveryExecution $deliveryExecution)
-    {
-        $compiledDelivery = $deliveryExecution->getDelivery();
-        $runtime = $this->getServiceLocator()->get(AssignmentService::CONFIG_ID)->getRuntime($compiledDelivery->getUri());
-        $inputParameters = \tao_models_classes_service_ServiceCallHelper::getInputValues($runtime, array());
-
-        return $inputParameters;
     }
 
     /**
@@ -131,7 +50,7 @@ class TestSessionService extends ConfigurableService
      */
     public function isExpired(DeliveryExecution $deliveryExecution)
     {
-        if (!isset($this->cache[$deliveryExecution->getIdentifier()]['expired'])) {
+        if (!isset(self::$cache[$deliveryExecution->getIdentifier()]['expired'])) {
             $executionState = $deliveryExecution->getState()->getUri();
             if (!in_array($executionState, [
                 DeliveryExecutionState::STATE_PAUSED,
@@ -140,7 +59,7 @@ class TestSessionService extends ConfigurableService
                 DeliveryExecutionState::STATE_AUTHORIZED,
             ]) ||
                 !$lastTestTakersEvent = $this->getLastTestTakersEvent($deliveryExecution)) {
-                return $this->cache[$deliveryExecution->getIdentifier()]['expired'] = false;
+                return self::$cache[$deliveryExecution->getIdentifier()]['expired'] = false;
             }
 
             /** @var \oat\taoProctoring\model\implementation\DeliveryExecutionStateService $deliveryExecutionStateService */
@@ -153,8 +72,8 @@ class TestSessionService extends ConfigurableService
                 $startedTimestamp = \tao_helpers_Date::getTimeStamp($deliveryExecution->getStartTime(), true);
                 $started = (new DateTimeImmutable())->setTimestamp($startedTimestamp);
                 if ($started->add(new DateInterval($delay)) < (new DateTimeImmutable())) {
-                    $this->cache[$deliveryExecution->getIdentifier()]['expired'] = true;
-                    return $this->cache[$deliveryExecution->getIdentifier()]['expired'];
+                    self::$cache[$deliveryExecution->getIdentifier()]['expired'] = true;
+                    return self::$cache[$deliveryExecution->getIdentifier()]['expired'];
                 }
             }
 
@@ -162,26 +81,16 @@ class TestSessionService extends ConfigurableService
             if ($wasPausedAt && $deliveryExecutionStateService->hasOption(DeliveryExecutionStateService::OPTION_TERMINATION_DELAY_AFTER_PAUSE)) {
                 $delay = $deliveryExecutionStateService->getOption(DeliveryExecutionStateService::OPTION_TERMINATION_DELAY_AFTER_PAUSE);
                 if ($wasPausedAt->add(new DateInterval($delay)) < (new DateTimeImmutable())) {
-                    $this->cache[$deliveryExecution->getIdentifier()]['expired'] = true;
+                    self::$cache[$deliveryExecution->getIdentifier()]['expired'] = true;
 
-                    return $this->cache[$deliveryExecution->getIdentifier()]['expired'];
+                    return self::$cache[$deliveryExecution->getIdentifier()]['expired'];
                 }
             }
 
-            $this->cache[$deliveryExecution->getIdentifier()]['expired'] = false;
+            self::$cache[$deliveryExecution->getIdentifier()]['expired'] = false;
         }
 
-        return $this->cache[$deliveryExecution->getIdentifier()]['expired'];
-    }
-
-    /**
-     * @param AssessmentTestSession $session
-     */
-    public function persist(AssessmentTestSession $session)
-    {
-        $sessionId = $session->getSessionId();
-        $storage = $this->cache[$sessionId]['storage'];
-        $storage->persist($session);
+        return self::$cache[$deliveryExecution->getIdentifier()]['expired'];
     }
 
     /**

--- a/scripts/install/RegisterRunnerMessageService.php
+++ b/scripts/install/RegisterRunnerMessageService.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ *
+ */
+
+namespace oat\taoProctoring\scripts\install;
+
+use oat\oatbox\extension\InstallAction;
+use oat\taoProctoring\model\implementation\TestRunnerMessageService;
+
+/**
+ * Class RegisterRunnerMessageService
+ * @package oat\taoProctoring\scripts\install
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+class RegisterRunnerMessageService extends InstallAction
+{
+    public function __invoke($params)
+    {
+        $service = new TestRunnerMessageService();
+        $this->registerService(TestRunnerMessageService::SERVICE_ID, $service);
+    }
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -48,6 +48,7 @@ use oat\taoProctoring\model\monitorCache\implementation\MonitoringStorage;
 use oat\taoProctoring\model\ProctorService;
 use oat\taoProctoring\model\ReasonCategoryService;
 use oat\taoProctoring\scripts\install\RegisterBreadcrumbsServices;
+use oat\taoProctoring\scripts\install\RegisterRunnerMessageService;
 use oat\taoQtiTest\models\event\QtiTestStateChangeEvent;
 use oat\taoTests\models\event\TestChangedEvent;
 
@@ -221,5 +222,12 @@ class Updater extends common_ext_ExtensionUpdater
         }
 
         $this->skip('4.9.1', '4.10.9');
+
+        if ($this->isVersion('4.10.9')) {
+            
+            $this->runExtensionScript(RegisterRunnerMessageService::class);
+            
+            $this->setVersion('4.11.0');
+        }
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3942

Requires: https://github.com/oat-sa/extension-tao-testqti/pull/779

Override the TestRunner Message service to provide different pause message if the proctor is the sender.

Also move the `TestSessionService` to the taoQtiTest extension. At least the part that is only related to QTI test.