### PR TITLE
Fix/tao 4128 dont forward authorized deliveries to execution

### DIFF
--- a/controller/DeliveryServer.php
+++ b/controller/DeliveryServer.php
@@ -76,12 +76,12 @@ class DeliveryServer extends DefaultDeliveryServer
     /**
      * Displays the execution screen
      *
-     * FIXME all state management must be centralized into a service, 
+     * FIXME all state management must be centralized into a service,
       * it should'nt be on the controller.
      *
      * @throws common_exception_Error
      */
-    public function runDeliveryExecution() 
+    public function runDeliveryExecution()
     {
         $deliveryExecution = $this->getCurrentDeliveryExecution();
         $deliveryExecutionStateService = $this->getServiceManager()->get(DeliveryExecutionStateService::SERVICE_ID);
@@ -94,7 +94,7 @@ class DeliveryServer extends DefaultDeliveryServer
     /**
      * The awaiting authorization screen
      */
-    public function awaitingAuthorization() 
+    public function awaitingAuthorization()
     {
         $deliveryExecution = $this->getCurrentDeliveryExecution();
         $deliveryExecutionStateService = $this->getServiceManager()->get(DeliveryExecutionStateService::SERVICE_ID);
@@ -136,7 +136,7 @@ class DeliveryServer extends DefaultDeliveryServer
             return $this->redirect($this->getReturnUrl());
         }
     }
-    
+
     /**
      * The action called to check if the requested delivery execution has been authorized by the proctor
      */
@@ -148,19 +148,19 @@ class DeliveryServer extends DefaultDeliveryServer
         $authorized = false;
         $success = true;
         $message = null;
-        
+
         // reacts to a few particular states
         switch ($executionState) {
             case DeliveryExecutionState::STATE_AUTHORIZED:
                     $authorized = true;
                 break;
-            
+
             case DeliveryExecutionState::STATE_TERMINATED:
             case DeliveryExecutionState::STATE_FINISHED:
                 $success = false;
                 $message = __('The assessment has been terminated.');
                 break;
-                
+
             case DeliveryExecutionState::STATE_PAUSED:
                 $success = false;
                 $message = __('The assessment has been suspended by an authorized proctor. If you wish to resume your assessment, please relaunch it and contact your proctor if required.');

--- a/manifest.php
+++ b/manifest.php
@@ -41,7 +41,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '4.15.0',
+    'version' => '4.15.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=7.81.1',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -275,5 +275,7 @@ class Updater extends common_ext_ExtensionUpdater
             $this->getServiceManager()->register(EventManager::SERVICE_ID, $eventManager);
             $this->setVersion('4.15.0');
         }
+
+        $this->skip('4.15.0', '4.15.1');
     }
 }

--- a/views/js/controller/DeliveryServer/awaiting.js
+++ b/views/js/controller/DeliveryServer/awaiting.js
@@ -39,7 +39,7 @@ define([
      * The polling delay used to refresh the list
      * @type {Number}
      */
-    var refreshPolling = 1 * 1000; // once every 1 second
+    var refreshPolling = 10 * 1000; // once every 10 seconds
 
     /**
      * The CSS scope
@@ -130,7 +130,9 @@ define([
                 },
                 interval : refreshPolling,
                 autoStart : true
-            });
+            })
+            // Trigger the action immediately
+            .next();
 
             /**
              * Function to be called when the delivery execution has been authorized

--- a/views/js/controller/DeliveryServer/awaiting.js
+++ b/views/js/controller/DeliveryServer/awaiting.js
@@ -39,7 +39,7 @@ define([
      * The polling delay used to refresh the list
      * @type {Number}
      */
-    var refreshPolling = 10 * 1000; // once every 10 seconds
+    var refreshPolling = 1 * 1000; // once every 1 second
 
     /**
      * The CSS scope


### PR DESCRIPTION
Notes:

- The short polling frequency was reduced to 1 second. This prevents test takers from waiting 10 seconds before proceeding to test after a browser refresh on an authorized test. Please let me know any opinions on this. I understand we need to account for limited connectivity, but I don't believe a ~400B response will be impactful, even at 1 second intervals. Another option would be to keep a 10 second poll timeout, but update `core/polling` to immediately call the passed action instead of waiting for the timeout. Perhaps @ssipasseuth can comment on the best path for this.

- There is still a path to directly launching an authorized delivery. If a delivery is authorized and the test taker launches test from lti (as opposed to refreshing the screen), they will go directly to the delivery (instead of the 'awaitingAuthorization' page). This is due to the nature of the [taoDelivery extension](https://github.com/oat-sa/extension-tao-delivery/blob/master/controller/DeliveryServer.php#L187). The try/catch block will forward non-authorized deliveries to the 'awaitingAuthorization' page. I think updating the flow of taoDelivery is outside the scope of this ticket and thus will leave this shortcoming intact.