### PR TITLE
Feature/tao 4249 approx countdown

### DIFF
--- a/config/default/DeliveryExecutionState.conf.php
+++ b/config/default/DeliveryExecutionState.conf.php
@@ -6,4 +6,6 @@ use oat\taoProctoring\model\implementation\DeliveryExecutionStateService;
 return new DeliveryExecutionStateService([
     DeliveryExecutionStateService::OPTION_TERMINATION_DELAY_AFTER_PAUSE => 'PT1H',
     DeliveryExecutionStateService::OPTION_TIME_HANDLING => false,
+    DeliveryExecutionStateService::OPTION_APPROXIMATE_TIMER => false,
+    DeliveryExecutionStateService::OPTION_APPROXIMATE_TIMER_WARNING => 1440,
 ]);

--- a/config/default/DeliveryExecutionState.conf.php
+++ b/config/default/DeliveryExecutionState.conf.php
@@ -7,5 +7,5 @@ return new DeliveryExecutionStateService([
     DeliveryExecutionStateService::OPTION_TERMINATION_DELAY_AFTER_PAUSE => 'PT1H',
     DeliveryExecutionStateService::OPTION_TIME_HANDLING => false,
     DeliveryExecutionStateService::OPTION_APPROXIMATE_TIMER => false,
-    DeliveryExecutionStateService::OPTION_APPROXIMATE_TIMER_WARNING => 1440,
+    DeliveryExecutionStateService::OPTION_APPROXIMATE_TIMER_WARNING => 900,
 ]);

--- a/controller/Delivery.php
+++ b/controller/Delivery.php
@@ -79,7 +79,7 @@ class Delivery extends ProctoringModule
 
         /** @var $assessmentResultsService \oat\taoProctoring\model\AssessmentResultsService */
         $assessmentResultsService = $this->getServiceManager()->get(AssessmentResultsService::CONFIG_ID);
-        
+
         /** @var $deliveryExecutionStateService \oat\taoProctoring\model\implementation\DeliveryExecutionStateService */
         $deliveryExecutionStateService = $this->getServiceManager()->get(DeliveryExecutionStateService::SERVICE_ID);
 
@@ -94,6 +94,8 @@ class Delivery extends ProctoringModule
                 'categories' => $this->getAllReasonsCategories(),
                 'printReportButton' => json_encode($assessmentResultsService->getOption(AssessmentResultsService::OPTION_PRINT_REPORT_BUTTON)),
                 'timeHandling' => json_encode($deliveryExecutionStateService->getOption(DeliveryExecutionStateService::OPTION_TIME_HANDLING)),
+                'approximateTimer' => json_encode($deliveryExecutionStateService->getOption(DeliveryExecutionStateService::OPTION_APPROXIMATE_TIMER)),
+                'approximateTimerWarning' => json_encode($deliveryExecutionStateService->getOption(DeliveryExecutionStateService::OPTION_APPROXIMATE_TIMER_WARNING)),
                 'refreshBtn' => $this->getServiceManager()->get(GuiSettingsService::SERVICE_ID)->getOption(GuiSettingsService::PROCTORING_REFRESH_BUTTON),
                 'autoRefresh' => $this->getServiceManager()->get(GuiSettingsService::SERVICE_ID)->getOption(GuiSettingsService::PROCTORING_AUTO_REFRESH),
             ),
@@ -136,6 +138,8 @@ class Delivery extends ProctoringModule
                 'categories' => $this->getAllReasonsCategories(),
                 'printReportButton' => json_encode($assessmentResultsService->getOption(AssessmentResultsService::OPTION_PRINT_REPORT_BUTTON)),
                 'timeHandling' => json_encode($deliveryExecutionStateService->getOption(DeliveryExecutionStateService::OPTION_TIME_HANDLING)),
+                'approximateTimer' => json_encode($deliveryExecutionStateService->getOption(DeliveryExecutionStateService::OPTION_APPROXIMATE_TIMER)),
+                'approximateTimerWarning' => json_encode($deliveryExecutionStateService->getOption(DeliveryExecutionStateService::OPTION_APPROXIMATE_TIMER_WARNING)),
                 'refreshBtn' => $this->getServiceManager()->get(GuiSettingsService::SERVICE_ID)->getOption(GuiSettingsService::PROCTORING_REFRESH_BUTTON),
                 'autoRefresh' => $this->getServiceManager()->get(GuiSettingsService::SERVICE_ID)->getOption(GuiSettingsService::PROCTORING_AUTO_REFRESH),
             ),
@@ -550,7 +554,7 @@ class Delivery extends ProctoringModule
 
     /**
      * Extra Time handling: add or remove time on delivery executions
-     * 
+     *
      * @throws \common_Exception
      */
     public function extraTime()

--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '3.17.2',
+    'version' => '3.18.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=7.23.0',

--- a/model/implementation/DeliveryExecutionStateService.php
+++ b/model/implementation/DeliveryExecutionStateService.php
@@ -41,7 +41,9 @@ class DeliveryExecutionStateService extends ConfigurableService implements \oat\
 {
     const OPTION_TERMINATION_DELAY_AFTER_PAUSE = 'termination_delay_after_pause';
     const OPTION_TIME_HANDLING = 'time_handling';
-    
+    const OPTION_APPROXIMATE_TIMER = 'approximate_timer';
+    const OPTION_APPROXIMATE_TIMER_WARNING = 'approximate_timer_warning';
+
     /**
      * @var TestSessionService
      */

--- a/model/monitorCache/DeliveryMonitoringService.php
+++ b/model/monitorCache/DeliveryMonitoringService.php
@@ -44,7 +44,9 @@ interface DeliveryMonitoringService
     const REMAINING_TIME = 'remaining_time';
     const EXTRA_TIME = 'extra_time';
     const CONSUMED_EXTRA_TIME = 'consumed_extra_time';
-    const LAST_ACTIVITY = 'last_activity';
+    const LAST_TEST_TAKER_ACTIVITY = 'last_test_taker_activity';
+    const LAST_TEST_STATE_CHANGE = 'last_test_state_change';
+    const LAST_PAUSE_TIMESTAMP = 'last_pause_timestamp';
 
 
     const TEST_TAKER_FIRST_NAME = 'test_taker_first_name';

--- a/model/monitorCache/DeliveryMonitoringService.php
+++ b/model/monitorCache/DeliveryMonitoringService.php
@@ -44,6 +44,7 @@ interface DeliveryMonitoringService
     const REMAINING_TIME = 'remaining_time';
     const EXTRA_TIME = 'extra_time';
     const CONSUMED_EXTRA_TIME = 'consumed_extra_time';
+    const LAST_ACTIVITY = 'last_activity';
 
 
     const TEST_TAKER_FIRST_NAME = 'test_taker_first_name';

--- a/model/monitorCache/implementation/DeliveryMonitoringData.php
+++ b/model/monitorCache/implementation/DeliveryMonitoringData.php
@@ -342,7 +342,7 @@ class DeliveryMonitoringData implements DeliveryMonitoringDataInterface
 
         $this->addValue(DeliveryMonitoringService::REMAINING_TIME, $result, true);
     }
-    
+
     /**
      * Update extra time allowed for the delivery execution
      */
@@ -351,6 +351,14 @@ class DeliveryMonitoringData implements DeliveryMonitoringDataInterface
         $timer = DeliveryHelper::getDeliveryTimer($this->deliveryExecution);
         $this->addValue(DeliveryMonitoringService::EXTRA_TIME, $timer->getExtraTime(), true);
         $this->addValue(DeliveryMonitoringService::CONSUMED_EXTRA_TIME, $timer->getConsumedExtraTime(), true);
+    }
+
+    /**
+     * Update extra time allowed for the delivery execution
+     */
+    private function updateLastActivity()
+    {
+        $this->addValue(DeliveryMonitoringService::LAST_ACTIVITY, microtime(true), true);
     }
 
     /**

--- a/model/monitorCache/implementation/DeliveryMonitoringData.php
+++ b/model/monitorCache/implementation/DeliveryMonitoringData.php
@@ -33,8 +33,6 @@ use oat\oatbox\service\ServiceManager;
 use oat\taoProctoring\model\execution\DeliveryExecution as ProctoredDeliveryExecution;
 use oat\taoProctoring\model\TestSessionConnectivityStatusService;
 use oat\taoQtiTest\models\runner\session\TestSession;
-use oat\taoQtiTest\models\runner\time\QtiTimer;
-use oat\taoQtiTest\models\runner\time\QtiTimeStorage;
 use qtism\runtime\tests\AssessmentTestSession;
 use oat\taoDelivery\model\execution\DeliveryExecution;
 
@@ -215,6 +213,10 @@ class DeliveryMonitoringData implements DeliveryMonitoringDataInterface
         $deliveryExecutionStateService = $this->getServiceManager()->get(DeliveryExecutionStateService::SERVICE_ID);
         $status = $deliveryExecutionStateService->getState($this->deliveryExecution);
         $this->addValue(DeliveryMonitoringService::STATUS, $status, true);
+        $this->addValue(DeliveryMonitoringService::LAST_TEST_STATE_CHANGE, microtime(true), true);
+        if ($status == ProctoredDeliveryExecution::STATE_PAUSED) {
+            $this->addValue(DeliveryMonitoringService::LAST_PAUSE_TIMESTAMP, microtime(true), true);
+        }
     }
 
     /**
@@ -356,9 +358,9 @@ class DeliveryMonitoringData implements DeliveryMonitoringDataInterface
     /**
      * Update extra time allowed for the delivery execution
      */
-    private function updateLastActivity()
+    private function updateLastTestTakerActivity()
     {
-        $this->addValue(DeliveryMonitoringService::LAST_ACTIVITY, microtime(true), true);
+        $this->addValue(DeliveryMonitoringService::LAST_TEST_TAKER_ACTIVITY, microtime(true), true);
     }
 
     /**

--- a/model/monitorCache/implementation/DeliveryMonitoringService.php
+++ b/model/monitorCache/implementation/DeliveryMonitoringService.php
@@ -79,7 +79,9 @@ class DeliveryMonitoringService extends ConfigurableService implements DeliveryM
     const COLUMN_REMAINING_TIME = DeliveryMonitoringServiceInterface::REMAINING_TIME;
     const COLUMN_EXTRA_TIME = DeliveryMonitoringServiceInterface::EXTRA_TIME;
     const COLUMN_CONSUMED_EXTRA_TIME = DeliveryMonitoringServiceInterface::CONSUMED_EXTRA_TIME;
-    const COLUMN_LAST_ACTIVITY = DeliveryMonitoringServiceInterface::LAST_ACTIVITY;
+    const COLUMN_LAST_TEST_TAKER_ACTIVITY = DeliveryMonitoringServiceInterface::LAST_TEST_TAKER_ACTIVITY;
+    const COLUMN_LAST_TEST_STATE_CHANGE = DeliveryMonitoringServiceInterface::LAST_TEST_STATE_CHANGE;
+    const COLUMN_LAST_PAUSE_TIMESTAMP = DeliveryMonitoringServiceInterface::LAST_PAUSE_TIMESTAMP;
 
     const KV_TABLE_NAME = 'kv_delivery_monitoring';
     const KV_COLUMN_ID = 'id';

--- a/model/monitorCache/implementation/DeliveryMonitoringService.php
+++ b/model/monitorCache/implementation/DeliveryMonitoringService.php
@@ -79,6 +79,7 @@ class DeliveryMonitoringService extends ConfigurableService implements DeliveryM
     const COLUMN_REMAINING_TIME = DeliveryMonitoringServiceInterface::REMAINING_TIME;
     const COLUMN_EXTRA_TIME = DeliveryMonitoringServiceInterface::EXTRA_TIME;
     const COLUMN_CONSUMED_EXTRA_TIME = DeliveryMonitoringServiceInterface::CONSUMED_EXTRA_TIME;
+    const COLUMN_LAST_ACTIVITY = DeliveryMonitoringServiceInterface::LAST_ACTIVITY;
 
     const KV_TABLE_NAME = 'kv_delivery_monitoring';
     const KV_COLUMN_ID = 'id';
@@ -116,7 +117,7 @@ class DeliveryMonitoringService extends ConfigurableService implements DeliveryM
         if ($updateData) {
             $this->data[$id]->updateData();
         }
-        
+
         return $this->data[$id];
     }
 
@@ -169,7 +170,7 @@ class DeliveryMonitoringService extends ConfigurableService implements DeliveryM
      *    [['error_code' => ['0', '1']],
      * ]);
      * ```
-     * 
+     *
      * @param array $criteria - criteria to find data.
      * The comparison operator is determined based on the first few
      * characters in the given value. It recognizes the following operators
@@ -520,7 +521,7 @@ class DeliveryMonitoringService extends ConfigurableService implements DeliveryM
     {
         $whereClause = '';
 
-        //if condition is [ [ key => val ] ] then flatten to [ key => val ] 
+        //if condition is [ [ key => val ] ] then flatten to [ key => val ]
         if (is_array($condition) && count($condition) === 1 && is_array(current($condition)) && gettype(array_keys($condition)[0]) == 'integer' ) {
             $condition = current($condition);
         }

--- a/model/monitorCache/update/TestUpdate.php
+++ b/model/monitorCache/update/TestUpdate.php
@@ -22,7 +22,6 @@
 namespace oat\taoProctoring\model\monitorCache\update;
 
 use oat\taoProctoring\model\monitorCache\DeliveryMonitoringService;
-use oat\taoQtiTest\models\event\QtiMoveEvent;
 use oat\taoQtiTest\models\event\QtiTestChangeEvent;
 use oat\oatbox\service\ServiceManager;
 use qtism\runtime\tests\AssessmentTestSessionState;
@@ -37,11 +36,6 @@ class TestUpdate
 
     public static function testStateChange(QtiTestChangeEvent $event)
     {
-        $session = $event->getSession();
-        $sessionMemento = $event->getSessionMemento();
-        $currentItem = $session->getCurrentAssessmentItemRef();
-        $previousItem = $sessionMemento->getItem();
-
         $dataKeys = [
             DeliveryMonitoringService::STATUS,
             DeliveryMonitoringService::CURRENT_ASSESSMENT_ITEM,
@@ -50,10 +44,10 @@ class TestUpdate
             DeliveryMonitoringService::REMAINING_TIME,
             DeliveryMonitoringService::EXTRA_TIME,
         ];
-        if (($session->getState() == AssessmentTestSessionState::INTERACTING) &&
-            ($session->getState() != $sessionMemento->getState() || //!$currentItem || !$previousItem ||
-             $previousItem->getIdentifier() != $currentItem->getIdentifier())) {
-            $dataKeys[] = DeliveryMonitoringService::LAST_ACTIVITY;
+
+        $session = $event->getSession();
+        if ($session->getState() == AssessmentTestSessionState::INTERACTING) {
+            $dataKeys[] = DeliveryMonitoringService::LAST_TEST_TAKER_ACTIVITY;
         }
 
         /** @var DeliveryMonitoringService $service */

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -668,6 +668,28 @@ class Updater extends common_ext_ExtensionUpdater
         }
 
         $this->skip('3.17.0', '3.17.2');
+
+        if ($this->isVersion('3.17.2')) {
+            try {
+                $service = $this->getServiceManager()->get(DeliveryExecutionStateService::SERVICE_ID);
+            } catch (ServiceNotFoundException $e) {
+                $service = new DeliveryExecutionStateService(
+                    [
+                        DeliveryExecutionStateService::OPTION_TERMINATION_DELAY_AFTER_PAUSE => 'PT1H',
+                        DeliveryExecutionStateService::OPTION_TIME_HANDLING => false,
+                        DeliveryExecutionStateService::OPTION_APPROXIMATE_TIMER => false,
+                    ]
+                );
+            }
+
+            $service->setOption(DeliveryExecutionStateService::OPTION_APPROXIMATE_TIMER, false);
+            $service->setOption(DeliveryExecutionStateService::OPTION_APPROXIMATE_TIMER_WARNING, 1440);
+
+            $this->getServiceManager()->propagate($service);
+            $this->getServiceManager()->register(DeliveryExecutionStateService::SERVICE_ID, $service);
+
+            $this->setVersion('3.18.0');
+        }
     }
 
     private function refreshMonitoringData()

--- a/views/js/templates/delivery/approximatedTimer.tpl
+++ b/views/js/templates/delivery/approximatedTimer.tpl
@@ -1,0 +1,4 @@
+{{#if timer}}
+<span class="approximated-timer" {{#if since}} title="{{since}}"{{/if}}>~{{timer}}</span>
+{{#if since}}<span class="icon-warning" title="{{since}}"></span>{{/if}}
+{{/if}}


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-4249

Implement the timer countdown approximation on the proctor monitoring page.
On every page refresh (manual or automatic), the timer of each running delivery should be updated.
This is an approximation, so some discrepancies may appear. After a defined period of time a visual signal should alert the timer is based on an innacurate value as the test taker seems to do not have done anything since a significant period.

This feature is based on a platform option, disabled by default. To enable it you can change the config `approximate_timer` in the file `config/taoProctoring/DeliveryExecutionState.conf.php`, or check out the companion PR related to the customer.