### PR TITLE
Fix/extra timer countdown

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '3.18.0',
+    'version' => '3.18.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=7.23.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -690,6 +690,8 @@ class Updater extends common_ext_ExtensionUpdater
 
             $this->setVersion('3.18.0');
         }
+
+        $this->skip('3.18.0', '3.18.1');
     }
 
     private function refreshMonitoringData()

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -673,7 +673,7 @@ define([
                             refinedValue = '';
                         }
 
-                        if (!remaining || (timer.extraTime && timer.extraTime <= timer.consumedExtraTime)) {
+                        if (!remaining && !timer.extraTime || (timer.extraTime && timer.extraTime <= timer.consumedExtraTime)) {
                             refinedValue = __('Timed out');
                         } else {
                             refinedValue += encodeExtraTime(timer.extraTime, timer.consumedExtraTime, __('%s min'), extraTimeUnit);

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -662,8 +662,10 @@ define([
                     var since = parseInt(timer.since, 10);
 
                     if (remaining || _.isFinite(remaining) ) {
-                        if (remaining < 0 && timer.extraTime) {
-                            timer.consumedExtraTime += -remaining;
+                        if (remaining < 0) {
+                            if (timer.extraTime) {
+                                timer.consumedExtraTime += -remaining;
+                            }
                             remaining = 0;
                         }
 
@@ -673,7 +675,7 @@ define([
                             refinedValue = '';
                         }
 
-                        if (!remaining && !timer.extraTime || (timer.extraTime && timer.extraTime <= timer.consumedExtraTime)) {
+                        if ((!remaining && !timer.extraTime) || (timer.extraTime && timer.extraTime <= timer.consumedExtraTime)) {
                             refinedValue = __('Timed out');
                         } else {
                             refinedValue += encodeExtraTime(timer.extraTime, timer.consumedExtraTime, __('%s min'), extraTimeUnit);


### PR DESCRIPTION
Fix the issue occurring on the timer countdown when the timer is over and extra time is still running: a timeout is displayed instead of the extra remaining time

Also fix the negative timer occurring when an assessment is left without reset: TT simply closes the page without returning to the index, the test remains in running state and the timer is still counting down, falling to negative value once the time is over