### PR TITLE
resume unproctored paused tests

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '5.1.1',
+    'version' => '5.1.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=9.0.0',

--- a/model/authorization/TestTakerAuthorizationService.php
+++ b/model/authorization/TestTakerAuthorizationService.php
@@ -20,12 +20,14 @@
 namespace oat\taoProctoring\model\authorization;
 
 use oat\oatbox\service\ConfigurableService;
+use oat\taoProctoring\helpers\DeliveryHelper;
 use oat\taoDelivery\model\authorization\AuthorizationProvider;
 use oat\taoDelivery\model\execution\DeliveryExecution;
 use oat\taoProctoring\model\execution\DeliveryExecution as ProctoredDeliveryExecution;
 use oat\taoDelivery\model\authorization\UnAuthorizedException;
 use oat\oatbox\user\User;
 use oat\taoDeliveryRdf\model\guest\GuestTestUser;
+use oat\taoProctoring\model\DeliveryExecutionStateService;
 
 /**
  * Manage the Delivery authorization.
@@ -64,6 +66,12 @@ class TestTakerAuthorizationService extends ConfigurableService
         }
         if ($this->isProctored($deliveryExecution->getDelivery()->getUri(), $user) && $state !== ProctoredDeliveryExecution::STATE_AUTHORIZED) {
             $this->throwUnAuthorizedException($deliveryExecution);
+        }
+
+        //resume unproctored paused tests
+        if(!$this->isProctored($deliveryExecution->getDelivery()->getUri(), $user) && $state == ProctoredDeliveryExecution::STATE_PAUSED  ){
+            $deliveryExecutionStateService = $this->getServiceManager()->get(DeliveryExecutionStateService::SERVICE_ID);
+            $deliveryExecutionStateService->resumeExecution($deliveryExecution);
         }
     }
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -303,5 +303,7 @@ class Updater extends common_ext_ExtensionUpdater
             $this->getServiceManager()->register(ActivityMonitoringService::SERVICE_ID, $service);
             $this->setVersion('5.1.1');
         }
+
+        $this->skip('5.1.1', '5.1.2');
     }
 }


### PR DESCRIPTION
When using LTI `proctored=false` the GuestTestUser isn't used for unproctored tests.
May be there's a better place to put the resume operation.