### PR TITLE
Use set/get route to access urlservice options

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,10 +43,10 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '5.7.0',
+    'version' => '5.7.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
-        'tao' => '>=10.3.1',
+        'tao' => '>=10.3.2',
         'taoDelivery' => '>=5.0.0',
         'taoDeliveryRdf' => '>=1.0',
         'taoTestTaker' => '>=2.6.0',

--- a/scripts/install/SetUpProctoringUrlService.php
+++ b/scripts/install/SetUpProctoringUrlService.php
@@ -29,13 +29,13 @@ class SetUpProctoringUrlService extends InstallAction
 {
     public function __invoke($params) {
         $urlService = $this->getServiceManager()->get(DefaultUrlService::SERVICE_ID);
-        $urlService->setOption('ProctoringHome', [
+        $urlService->setRoute('ProctoringHome', [
                 'ext' => 'taoProctoring',
                 'controller' => 'TestCenter',
                 'action' => 'index',
             ]
         );
-        $urlService->setOption('ProctoringLogout', [
+        $urlService->setRoute('ProctoringLogout', [
                 'ext' => 'tao',
                 'controller' => 'Main',
                 'action' => 'logout',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -313,6 +313,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('5.3.0');
         }
 
-        $this->skip('5.3.0', '5.7.0');
+        $this->skip('5.3.0', '5.7.1');
     }
 }


### PR DESCRIPTION
Create assessors to access configurable routes to make easier to override it
Requires https://github.com/oat-sa/tao-core/pull/1322