### PR TITLE
Fix/tao 4576 unhelpful proctor warning message

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -44,7 +44,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '5.16.4',
+    'version' => '5.16.5',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=10.24.0',

--- a/manifest.php
+++ b/manifest.php
@@ -44,7 +44,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '5.16.6',
+    'version' => '5.16.7',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=10.24.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -381,6 +381,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('5.16.0');
         }
 
-        $this->skip('5.16.0', '5.16.4');
+        $this->skip('5.16.0', '5.16.5');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -407,5 +407,7 @@ class Updater extends common_ext_ExtensionUpdater
             OntologyUpdater::syncModels();
             $this->setVersion('5.16.6');
         }
+
+        $this->skip('5.16.6', '5.16.7');
     }
 }

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -454,37 +454,65 @@ define([
                  * @param {Object[]} deniedResources
                  */
                 function buildWarningMessage(action, selection, deniedResources) {
+                    var maxReasons = 2;
                     var warningAction;
-                    var warningReasons;
-                    var warningMessage;
+                    var warningReason;
 
-                    if (deniedResources) {
-                        if (deniedResources.length > 1) {
-                            warningAction = __('Cannot %s these test sessions.', action);
-                            warningReasons = _(deniedResources)
-                                .map(function (deniedResource) {
-                                    return __('Test %s %s.', deniedResource.id, deniedResource.reason);
-                                })
-                                .slice(0, 2)
-                                .join(' ');
+                    deniedResources = deniedResources || [];
+                    selection = selection || [];
 
-                            if (deniedResources.length > 2) {
-                                warningReasons += __('...');
-                            }
+                    warningAction = getWarningAction(action, deniedResources.length > 1 || selection.length > 1);
+                    warningReason = _(deniedResources || [{}])
+                        .map(function (deniedResource, index) {
+                            return getWarningReason(deniedResource.reason, deniedResource.id || (index + 1));
+                        })
+                        .slice(0, maxReasons)
+                        .join(' ');
 
-                            warningMessage = __('%s %s', warningAction, warningReasons);
+                    if (deniedResources.length > maxReasons) {
+                        warningReason += __('...');
+                    }
+
+                    return warningAction + ' ' + warningReason;
+
+                    function getWarningAction(actionName, isPlural) {
+                        if (isPlural) {
+                            return {
+                                authorize: __('Cannot authorize test sessions.'),
+                                pause: __('Cannot pause test sessions.'),
+                                print: __('Cannot print test sessions.'),
+                                report: __('Cannot generate report on test sessions.'),
+                                terminate: __('Cannot terminate test sessions.'),
+                                time: __('Cannot extend test sessions.'),
+                                default: __('No report available for test sessions.')
+                            }[actionName || 'default'];
                         } else {
-                            warningMessage = __('Cannot %s this test session because test %s.', action, deniedResources[0].reason);
-                        }
-                    } else {
-                        if (selection.length > 1) {
-                            warningMessage = __('No report available for these test sessions.');
-                        } else {
-                            warningMessage = __('No report available for this test session.');
+                            return {
+                                authorize: __('Cannot authorize test session.'),
+                                pause: __('Cannot pause test session.'),
+                                print: __('Cannot print test session.'),
+                                report: __('Cannot generate report on test session.'),
+                                terminate: __('Cannot terminate test session.'),
+                                time: __('Cannot extend test session.'),
+                                default: __('No report available for test session.')
+                            }[actionName || 'default'];
                         }
                     }
 
-                    return warningMessage;
+                    function getWarningReason(reason, testId) {
+                        return {
+                            'already authorized': __('Test %s is already authorized.', testId),
+                            'not finished': __('Test %s is not finished.', testId),
+                            'not started': __('Test %s is not started.', testId),
+                            'not in progress': __('Test %s is not in progress.', testId),
+                            'is canceled': __('Test %s is canceled.', testId),
+                            'is completed': __('Test %s is completed.', testId),
+                            'is already paused': __('Test %s is already paused.', testId),
+                            'is paused': __('Test %s is paused.', testId),
+                            'is terminated': __('Test %s is terminated.', testId),
+                            'default': __('Action not allowed for test %s.', testId)
+                        }[reason || 'default'];
+                    }
                 }
 
                 /**

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -434,33 +434,9 @@ define([
                         reasonRequired: true,
                         categoriesSelector: cascadingComboBox(categories[actionName] || {})
                     });
-                    var warningAction;
-                    var warningMessage;
-                    var warningReasons;
 
                     if (!config.allowedResources.length) {
-                        if (config.deniedResources) {
-                            if (config.deniedResources.length > 1) {
-                                warningAction = __('Cannot') + ' ' + actionName + ' ' + __('these test sessions.');
-                                warningReasons += _.map(config.deniedResources, function (deniedResource, index) {
-                                    var opener = (index > 0 ? __('test') : __('Test')) + ' ';
-                                    return opener + deniedResource.id + ' ' + deniedResource.reason;
-                                }).join(',') + '.';
-                                warningMessage = warningAction + ' ' + warningReasons;
-                            } else {
-                                warningAction = __('Cannot') + ' ' + actionName;
-                                warningReasons = __('this test session') + ' ' + config.deniedResources[0].reason;
-                                warningMessage = warningAction + ' ' + __('because') + ' ' + warningReasons;
-                            }
-                        } else {
-                            if (_selection.length > 1) {
-                                warningMessage = __('No report available for these test sessions');
-                            } else {
-                                warningMessage = __('No report available for this test session.');
-                            }
-                        }
-
-                        feedback().warning(warningMessage);
+                        feedback().warning(buildWarningMessage(actionName, _selection, config.deniedResources));
                     } else {
                         bulkActionPopup(config).on('ok', function(reason){
                             //execute callback
@@ -469,6 +445,46 @@ define([
                             }
                         });
                     }
+                }
+
+                /**
+                 * Create a warning message for execBulkAction()
+                 * @param {String} action
+                 * @param {String[]} selection
+                 * @param {Object[]} deniedResources
+                 */
+                function buildWarningMessage(action, selection, deniedResources) {
+                    var warningAction;
+                    var warningReasons;
+                    var warningMessage;
+
+                    if (deniedResources) {
+                        if (deniedResources.length > 1) {
+                            warningAction = __('Cannot %s these test sessions.', action);
+                            warningReasons = _(deniedResources)
+                                .map(function (deniedResource) {
+                                    return __('Test %s %s.', deniedResource.id, deniedResource.reason);
+                                })
+                                .slice(0, 2)
+                                .join(' ');
+
+                            if (deniedResources.length > 2) {
+                                warningReasons += __('...');
+                            }
+
+                            warningMessage = __('%s %s', warningAction, warningReasons);
+                        } else {
+                            warningMessage = __('Cannot %s this test session because test %s.', action, deniedResources[0].reason);
+                        }
+                    } else {
+                        if (selection.length > 1) {
+                            warningMessage = __('No report available for these test sessions.');
+                        } else {
+                            warningMessage = __('No report available for this test session.');
+                        }
+                    }
+
+                    return warningMessage;
                 }
 
                 /**

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -434,23 +434,33 @@ define([
                         reasonRequired: true,
                         categoriesSelector: cascadingComboBox(categories[actionName] || {})
                     });
+                    var warningAction;
                     var warningMessage;
                     var warningReasons;
 
                     if (!config.allowedResources.length) {
-                        if (config.deniedResources && config.deniedResources.length > 1) {
-                            warningMessage = __('Cannot') + ' ' + actionName + ' ' + __('these test sessions.');
+                        if (config.deniedResources) {
+                            if (config.deniedResources.length > 1) {
+                                warningAction = __('Cannot') + ' ' + actionName + ' ' + __('these test sessions.');
+                                warningReasons += _.map(config.deniedResources, function (deniedResource, index) {
+                                    var opener = (index > 0 ? __('test') : __('Test')) + ' ';
+                                    return opener + deniedResource.id + ' ' + deniedResource.reason;
+                                }).join(',') + '.';
+                                warningMessage = warningAction + ' ' + warningReasons;
+                            } else {
+                                warningAction = __('Cannot') + ' ' + actionName;
+                                warningReasons = __('this test session') + ' ' + config.deniedResources[0].reason;
+                                warningMessage = warningAction + ' ' + __('because') + ' ' + warningReasons;
+                            }
                         } else {
-                            warningMessage = __('Cannot') + ' ' + actionName + ' ' + __('this test session.');
+                            if (_selection.length > 1) {
+                                warningMessage = __('No report available for these test sessions');
+                            } else {
+                                warningMessage = __('No report available for this test session.');
+                            }
                         }
 
-                        warningReasons = (config.deniedResources.length > 1 ? __('Reasons:') : __('Reason:')) + ' ';
-                        warningReasons += _.map(config.deniedResources, function (deniedResource, index) {
-                            var opener = (index > 0 ? __('test') : __('Test')) + ' ';
-                            return opener + deniedResource.id + ' ' + deniedResource.reason;
-                        }).join(',');
-
-                        feedback().warning(warningMessage + ' ' + warningReasons);
+                        feedback().warning(warningMessage);
                     } else {
                         bulkActionPopup(config).on('ok', function(reason){
                             //execute callback

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -498,15 +498,22 @@ define([
 
                     function getWarningReason(reason, testId) {
                         return {
-                            'already authorized': __('Test %s is already authorized.', testId),
-                            'not finished': __('Test %s is not finished.', testId),
-                            'not started': __('Test %s is not started.', testId),
-                            'not in progress': __('Test %s is not in progress.', testId),
-                            'is canceled': __('Test %s is canceled.', testId),
-                            'is completed': __('Test %s is completed.', testId),
-                            'is already paused': __('Test %s is already paused.', testId),
-                            'is paused': __('Test %s is paused.', testId),
-                            'is terminated': __('Test %s is terminated.', testId),
+                            // present perfect - for actions currently happening
+                            'not in progress': __('Test %s has not been in progress.', testId),
+
+                            // past perfect - for actions that have been completed
+                            'not finished': __('Test %s had not been finished.', testId),
+                            'not started': __('Test %s had not been started.', testId),
+                            'canceled': __('Test %s had been canceled.', testId),
+                            'completed': __('Test %s had been completed.', testId),
+                            'paused': __('Test %s had been paused.', testId),
+                            'terminated': __('Test %s had been terminated.', testId),
+
+                            // past perfect (with adjective) - for actions that have been completed but need emphasis to distinguish from the warning action (e.g. Canont terminate because test has 'already' been terminated.).
+                            'already authorized': __('Test %s had already been authorized.', testId),
+                            'already paused': __('Test %s had already been paused.', testId),
+                            'already terminated': __('Test %s had already been terminated', testId),
+
                             'default': __('Action not allowed for test %s.', testId)
                         }[reason || 'default'];
                     }

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -439,7 +439,7 @@ define([
                     });
 
                     if (!config.allowedResources.length) {
-                        feedback().warning(buildWarningMessage(actionName, _selection, config.deniedResources));
+                        feedback().warning(_status.buildWarningMessage(actionName, _selection, config.deniedResources));
                     } else {
                         bulkActionPopup(config).on('ok', function(reason){
                             //execute callback
@@ -448,71 +448,6 @@ define([
                             }
                         });
                     }
-                }
-
-                /**
-                 * Create a warning message for execBulkAction()
-                 * @param {String} action
-                 * @param {String[]} selection
-                 * @param {Object[]} deniedResources
-                 * @returns {String}
-                 */
-                function buildWarningMessage(action, selection, deniedResources) {
-                    var isPlural = selection.length > 1;
-                    var maxReasons = 2;
-                    var warningAction;
-                    var warningOmission = __('...');
-                    var warningReason;
-
-                    deniedResources = deniedResources || [{}];
-
-                    switch (action) {
-                        case 'authorize':
-                            warningAction = isPlural ?
-                                __('Cannot authorize test sessions.') :
-                                __('Cannot authorize test session.');
-                            break;
-                        case 'pause':
-                            warningAction = isPlural ?
-                                __('Cannot pause test sessions.') :
-                                __('Cannot pause test session.');
-                            break;
-                        case 'terminate':
-                            warningAction = isPlural ?
-                                __('Cannot terminate test sessions.') :
-                                __('Cannot terminate test session.');
-                            break;
-                        case 'report':
-                            warningAction = isPlural ?
-                                __('Cannot report test sessions.') :
-                                __('Cannot report test session.');
-                            break;
-                        case 'print':
-                            warningAction = isPlural ?
-                                __('Cannot print test sessions.') :
-                                __('Cannot print test session.');
-                            break;
-                        case 'time':
-                            warningAction = isPlural ?
-                                __('Cannot extend test sessions.') :
-                                __('Cannot extend test session.');
-                            break;
-                        default:
-                            warningAction = __('Cannot execute action.');
-                    }
-
-                    warningReason = _(deniedResources)
-                        .slice(0, maxReasons)
-                        .map(function (deniedResource) {
-                            return deniedResource.warning;
-                        })
-                        .join(' ');
-
-                    if (deniedResources.length > maxReasons) {
-                        warningReason += warningOmission;
-                    }
-
-                    return warningAction + ' ' + warningReason;
                 }
 
                 /**

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -434,13 +434,23 @@ define([
                         reasonRequired: true,
                         categoriesSelector: cascadingComboBox(categories[actionName] || {})
                     });
+                    var warningMessage;
+                    var warningReasons;
 
                     if (!config.allowedResources.length) {
-                        if (_selection.length > 1) {
-                            feedback().warning(__('No report available for these test sessions'));
+                        if (config.deniedResources && config.deniedResources.length > 1) {
+                            warningMessage = __('Cannot') + ' ' + actionName + ' ' + __('these test sessions.');
                         } else {
-                            feedback().warning(__('No report available for this test session'));
+                            warningMessage = __('Cannot') + ' ' + actionName + ' ' + __('this test session.');
                         }
+
+                        warningReasons = (config.deniedResources.length > 1 ? __('Reasons:') : __('Reason:')) + ' ';
+                        warningReasons += _.map(config.deniedResources, function (deniedResource, index) {
+                            var opener = (index > 0 ? __('test') : __('Test')) + ' ';
+                            return opener + deniedResource.id + ' ' + deniedResource.reason;
+                        }).join(',');
+
+                        feedback().warning(warningMessage + ' ' + warningReasons);
                     } else {
                         bulkActionPopup(config).on('ok', function(reason){
                             //execute callback

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -457,23 +457,20 @@ define([
                     var maxReasons = 2;
                     var warningAction;
                     var warningReason;
+                    var warningReasonOmission = __('...');
 
                     deniedResources = deniedResources || [];
                     selection = selection || [];
 
                     warningAction = getWarningAction(action, deniedResources.length > 1 || selection.length > 1);
                     warningReason = _(deniedResources || [{}])
+                        .slice(0, maxReasons)
                         .map(function (deniedResource, index) {
                             return getWarningReason(deniedResource.reason, deniedResource.id || (index + 1));
                         })
-                        .slice(0, maxReasons)
                         .join(' ');
 
-                    if (deniedResources.length > maxReasons) {
-                        warningReason += __('...');
-                    }
-
-                    return warningAction + ' ' + warningReason;
+                    return __('%s %s%s', warningAction, warningReason, (deniedResources.length > maxReasons ? warningReasonOmission : ''));
 
                     function getWarningAction(actionName, isPlural) {
                         if (isPlural) {

--- a/views/js/helper/status.js
+++ b/views/js/helper/status.js
@@ -356,7 +356,73 @@ define(['lodash', 'i18n'], function(_, __){
         });
     }
 
+    /**
+     * Create a warning message for execBulkAction()
+     * @param {String} action
+     * @param {String[]} selection
+     * @param {Object[]} deniedResources
+     * @returns {String}
+     */
+    function buildWarningMessage(action, selection, deniedResources) {
+        var isPlural = selection.length > 1;
+        var maxReasons = 2;
+        var warningAction;
+        var warningOmission = __('...');
+        var warningReason;
+
+        deniedResources = deniedResources || [{}];
+
+        switch (action) {
+            case 'authorize':
+                warningAction = isPlural ?
+                    __('Cannot authorize test sessions.') :
+                    __('Cannot authorize test session.');
+                break;
+            case 'pause':
+                warningAction = isPlural ?
+                    __('Cannot pause test sessions.') :
+                    __('Cannot pause test session.');
+                break;
+            case 'terminate':
+                warningAction = isPlural ?
+                    __('Cannot terminate test sessions.') :
+                    __('Cannot terminate test session.');
+                break;
+            case 'report':
+                warningAction = isPlural ?
+                    __('Cannot report test sessions.') :
+                    __('Cannot report test session.');
+                break;
+            case 'print':
+                warningAction = isPlural ?
+                    __('Cannot print test sessions.') :
+                    __('Cannot print test session.');
+                break;
+            case 'time':
+                warningAction = isPlural ?
+                    __('Cannot extend test sessions.') :
+                    __('Cannot extend test session.');
+                break;
+            default:
+                warningAction = __('Cannot execute action.');
+        }
+
+        warningReason = _(deniedResources)
+            .slice(0, maxReasons)
+            .map(function (deniedResource) {
+                return deniedResource.warning;
+            })
+            .join(' ');
+
+        if (deniedResources.length > maxReasons) {
+            warningReason += warningOmission;
+        }
+
+        return warningAction + ' ' + warningReason;
+    }
+
     return {
+        buildWarningMessage : buildWarningMessage,
         getStatuses : getStatuses,
         getStatus : getStatus,
         getStatusByCode : getStatusByCode,

--- a/views/js/helper/status.js
+++ b/views/js/helper/status.js
@@ -37,6 +37,26 @@ define(['lodash', 'i18n'], function(_, __){
                 report : true,
                 print : __('not finished'),
                 time : true
+            },
+            warning : {
+                authorize : function (username, testId) {
+                    if (testId) {
+                        return __('Test %s had already been authorized.', testId);
+                    } else if (username) {
+                        return __('%s\'s test had already been authorized.', username);
+                    } else {
+                        return __('Test had already been authorized.');
+                    }
+                },
+                print : function (username, testId) {
+                    if (testId) {
+                        return __('Test %s had not been finished.', testId);
+                    } else if (username) {
+                        return __('%s\'s test had not been finished.', username);
+                    } else {
+                        return __('Test had not been finished.');
+                    }
+                }
             }
         },
         authorized : {
@@ -49,6 +69,35 @@ define(['lodash', 'i18n'], function(_, __){
                 pause : __('not started'), //not in progress
                 print : __('not finished'),
                 time : true
+            },
+            warning : {
+                authorize : function (username, testId) {
+                    if (testId) {
+                        return __('Test %s had already been authorized.', testId);
+                    } else if (username) {
+                        return __('%s\'s test had already been authorized.', username);
+                    } else {
+                        return __('Test had already been authorized.');
+                    }
+                },
+                pause : function (username, testId) {
+                    if (testId) {
+                        return __('Test %s had not been started.', testId);
+                    } else if (username) {
+                        return __('%s\'s test had not been started.', username);
+                    } else {
+                        return __('Test had not been started.');
+                    }
+                },
+                print : function (username, testId) {
+                    if (testId) {
+                        return __('Test %s had not been finished.', testId);
+                    } else if (username) {
+                        return __('%s\'s test had not been finished.', username);
+                    } else {
+                        return __('Test had not been finished.');
+                    }
+                }
             }
         },
         awaiting : {
@@ -61,6 +110,26 @@ define(['lodash', 'i18n'], function(_, __){
                 report : true,
                 print : __('not finished'),
                 time : true
+            },
+            warning : {
+                pause : function (username, testId) {
+                    if (testId) {
+                        return __('Test %s had not been in progress.', testId);
+                    } else if (username) {
+                        return __('%s\'s test had not been in progress.', username);
+                    } else {
+                        return __('Test had not been in progress.');
+                    }
+                },
+                print : function (username, testId) {
+                    if (testId) {
+                        return __('Test %s had not been finished.', testId);
+                    } else if (username) {
+                        return __('%s\'s test had not been finished.', username);
+                    } else {
+                        return __('Test had not been finished.');
+                    }
+                }
             }
         },
         canceled : {
@@ -73,6 +142,44 @@ define(['lodash', 'i18n'], function(_, __){
                 report : true,
                 print: __('canceled'),
                 time : true
+            },
+            warning : {
+                authorize : function (username, testId) {
+                    if (testId) {
+                        return __('Test %s had been canceled.', testId);
+                    } else if (username) {
+                        return __('%s\'s test had been canceled.', username);
+                    } else {
+                        return __('Test had been canceled.');
+                    }
+                },
+                pause : function (username, testId) {
+                    if (testId) {
+                        return __('Test %s had been canceled.', testId);
+                    } else if (username) {
+                        return __('%s\'s test had been canceled.', username);
+                    } else {
+                        return __('Test had been canceled.');
+                    }
+                },
+                terminate : function (username, testId) {
+                    if (testId) {
+                        return __('Test %s had been canceled.', testId);
+                    } else if (username) {
+                        return __('%s\'s test had been canceled.', username);
+                    } else {
+                        return __('Test had been canceled.');
+                    }
+                },
+                print : function (username, testId) {
+                    if (testId) {
+                        return __('Test %s had been canceled.', testId);
+                    } else if (username) {
+                        return __('%s\'s test had been canceled.', username);
+                    } else {
+                        return __('Test had been canceled.');
+                    }
+                }
             }
         },
         completed : {
@@ -85,6 +192,35 @@ define(['lodash', 'i18n'], function(_, __){
                 report : true,
                 print: true,
                 time : true
+            },
+            warning : {
+                authorize : function (username, testId) {
+                    if (testId) {
+                        return __('Test %s had been completed.', testId);
+                    } else if (username) {
+                        return __('%s\'s test had been completed.', username);
+                    } else {
+                        return __('Test had been completed.');
+                    }
+                },
+                pause : function (username, testId) {
+                    if (testId) {
+                        return __('Test %s had been completed.', testId);
+                    } else if (username) {
+                        return __('%s\'s test had been completed.', username);
+                    } else {
+                        return __('Test had been completed.');
+                    }
+                },
+                terminate : function (username, testId) {
+                    if (testId) {
+                        return __('Test %s had been completed.', testId);
+                    } else if (username) {
+                        return __('%s\'s test had been completed.', username);
+                    } else {
+                        return __('Test had been completed.');
+                    }
+                }
             }
         },
         paused : {
@@ -97,6 +233,35 @@ define(['lodash', 'i18n'], function(_, __){
                 report : true,
                 print : __('not finished'),
                 time : true
+            },
+            warning : {
+                authorize : function (username, testId) {
+                    if (testId) {
+                        return __('Test %s had been paused.', testId);
+                    } else if (username) {
+                        return __('%s\'s test had been paused.', username);
+                    } else {
+                        return __('Test had been paused.');
+                    }
+                },
+                pause : function (username, testId) {
+                    if (testId) {
+                        return __('Test %s had already been paused.', testId);
+                    } else if (username) {
+                        return __('%s\'s test had already been paused.', username);
+                    } else {
+                        return __('Test had already been paused.');
+                    }
+                },
+                print : function (username, testId) {
+                    if (testId) {
+                        return __('Test %s had not been finished.', testId);
+                    } else if (username) {
+                        return __('%s\'s test had not been finished.', username);
+                    } else {
+                        return __('Test had not been finished.');
+                    }
+                }
             }
         },
         terminated : {
@@ -109,6 +274,35 @@ define(['lodash', 'i18n'], function(_, __){
                 report : true,
                 print: true,
                 time : true
+            },
+            warning : {
+                authorize : function (username, testId) {
+                    if (testId) {
+                        return __('Test %s had been terminated.', testId);
+                    } else if (username) {
+                        return __('%s\'s test had been terminated.', username);
+                    } else {
+                        return __('Test had been terminated.');
+                    }
+                },
+                pause : function (username, testId) {
+                    if (testId) {
+                        return __('Test %s had been terminated.', testId);
+                    } else if (username) {
+                        return __('%s\'s test had been terminated.', username);
+                    } else {
+                        return __('Test had been terminated.');
+                    }
+                },
+                terminate : function (username, testId) {
+                    if (testId) {
+                        return __('Test %s had already been terminated.', testId);
+                    } else if (username) {
+                        return __('%s\'s test had already been terminated.', username);
+                    } else {
+                        return __('Test had alredy been terminated.');
+                    }
+                },
             }
         }
     };

--- a/views/js/helper/status.js
+++ b/views/js/helper/status.js
@@ -67,11 +67,11 @@ define(['lodash', 'i18n'], function(_, __){
             code : _canceled,
             label : __('Canceled'),
             can : {
-                authorize : __('is canceled'),
-                pause : __('is canceled'),
-                terminate : __('is canceled'),
+                authorize : __('canceled'),
+                pause : __('canceled'),
+                terminate : __('canceled'),
                 report : true,
-                print: __('is canceled'),
+                print: __('canceled'),
                 time : true
             }
         },
@@ -79,9 +79,9 @@ define(['lodash', 'i18n'], function(_, __){
             code : _completed,
             label : __('Completed'),
             can : {
-                authorize : __('is completed'),
-                pause : __('is completed'),
-                terminate : __('is completed'),
+                authorize : __('completed'),
+                pause : __('completed'),
+                terminate : __('completed'),
                 report : true,
                 print: true,
                 time : true
@@ -91,8 +91,8 @@ define(['lodash', 'i18n'], function(_, __){
             code : _paused,
             label : __('Paused'),
             can : {
-                authorize : __('is paused'),
-                pause : __('is already paused'),
+                authorize : __('paused'),
+                pause : __('already paused'),
                 terminate : true,
                 report : true,
                 print : __('not finished'),
@@ -103,9 +103,9 @@ define(['lodash', 'i18n'], function(_, __){
             code : _terminated,
             label : __('Terminated'),
             can : {
-                authorize : __('is terminated'),
-                pause : __('is terminated'),
-                terminate : __('is terminated'),
+                authorize : __('terminated'),
+                pause : __('terminated'),
+                terminate : __('already terminated'),
                 report : true,
                 print: true,
                 time : true


### PR DESCRIPTION
Bugfix - ACT
Jira: https://oat-sa.atlassian.net/browse/TAO-4576

Description:
As a proctor, when receiving an error upon terminating session, the message “No report available for this test session” is displayed, but that message does not make sense for the scenario (i.e., termination).