### PR TITLE
Fix/tao 4836 displayed number

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -44,7 +44,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '6.1.1',
+    'version' => '6.1.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=10.28.0',

--- a/manifest.php
+++ b/manifest.php
@@ -44,7 +44,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '6.1.0',
+    'version' => '6.1.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=10.28.0',

--- a/model/datatable/DeliveriesMonitorDatatable.php
+++ b/model/datatable/DeliveriesMonitorDatatable.php
@@ -97,21 +97,23 @@ class DeliveriesMonitorDatatable implements DatatablePayload, ServiceLocatorAwar
         $executions = $service->getProctorableDeliveryExecutions($proctor, $this->delivery, $context, $options);
         $total = $service->countProctorableDeliveryExecutions($proctor, $this->delivery, $context, $options);
         $totalPages = ceil($total / $this->datatableRequest->getRows());
-        $result = $this->doPostProcessing($executions, $totalPages);
+        $result = $this->doPostProcessing($executions, $total, $totalPages);
 
         return $result;
     }
 
     /**
      * @param array $executionsData
-     * @param integer $total
+     * @param integer $amount
+     * @param integer $pages
      * @return array
      */
-    protected function doPostProcessing(array $executionsData, $total)
+    protected function doPostProcessing(array $executionsData, $amount, $pages)
     {
         return [
             'success' => true,
-            'total' => $total,
+            'amount' => $amount,
+            'total' => $pages,
             'page' => $this->datatableRequest->getPage(),
             'rows' => $this->datatableRequest->getRows(),
             'data' => DeliveryHelper::buildDeliveryExecutionData($executionsData),

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -446,6 +446,7 @@ class Updater extends common_ext_ExtensionUpdater
             }
             $this->setVersion('6.0.0');
         }
-        $this->skip('6.0.0', '6.1.0');
+
+        $this->skip('6.0.0', '6.1.1');
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-4836

Fix the response of the deliveryExecutions request in which the total amount of data was missing.
Now the displayed status of the table truly reflects the amount of data.