### PR TITLE
Fix/error without extra time

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -44,7 +44,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '7.4.1',
+    'version' => '7.4.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=10.28.0',

--- a/model/execution/DeliveryExecutionManagerService.php
+++ b/model/execution/DeliveryExecutionManagerService.php
@@ -81,11 +81,11 @@ class DeliveryExecutionManagerService extends ConfigurableService
     /**
      * Sets the extra time to a list of delivery executions
      * @param $deliveryExecutions
-     * @param null $extraTime
+     * @param int $extraTime
      * @param null $extendedTime
      * @return array
      */
-    public function setExtraTime($deliveryExecutions, $extraTime = null, $extendedTime = null)
+    public function setExtraTime($deliveryExecutions, $extraTime = 0, $extendedTime = null)
     {
         /** @var DeliveryMonitoringService $deliveryMonitoringService */
         $deliveryMonitoringService = $this->getServiceManager()->get(DeliveryMonitoringService::SERVICE_ID);

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -510,6 +510,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('7.4.0');
         }
 
-        $this->skip('7.4.0', '7.4.1');
+        $this->skip('7.4.0', '7.4.2');
     }
 }


### PR DESCRIPTION
We had situation where we had to interrupt a test. Without timers nor extra time sent, we has the following error : 

```
Debug Message
The specified interval specification cannot be processed as an ISO8601 duration.
Stack Trace
#0 /var/www/html/taoProctoring/model/execution/DeliveryExecutionManagerService.php(184): qtism\common\datatypes\QtiDuration->__construct('PTS')
#1 /var/www/html/ltiProctoring/model/LtiListenerService.php(171): oat\taoProctoring\model\execution\DeliveryExecutionManagerService->setExtraTime(Array, NULL, 1)
#2 /var/www/html/ltiProctoring/model/LtiListenerService.php(149): oat\ltiProctoring\model\LtiListenerService->updateDeliveryExtendedTime(Object(oat\taoDelivery\model\execution\DeliveryExecution), 1)
#3 /var/www/html/ltiProctoring/model/LtiListenerService.php(132): oat\ltiProctoring\model\LtiListenerService->checkExtendedTime(Object(taoLti_models_classes_LtiLaunchData), Object(oat\taoDelivery\model\execution\DeliveryExecution))
#4 [internal function]: oat\ltiProctoring\model\LtiListenerService->executionStateChanged(Object(oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState))
#5 /var/www/html/generis/common/oatbox/event/EventManager.php(55): call_user_func(Array, Object(oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState))
#6 /var/www/html/taoDelivery/model/execution/AbstractStateService.php(90): oat\oatbox\event\EventManager->trigger(Object(oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState))
#7 /var/www/html/taoProctoring/model/implementation/DeliveryExecutionStateService.php(288): oat\taoDelivery\model\execution\AbstractStateService->setState(Object(oat\taoDelivery\model\execution\DeliveryExecution), 'http://www.tao....', NULL)
#8 /var/www/html/ltiDeliveryProvider/controller/DeliveryRunner.php(130): oat\taoProctoring\model\implementation\DeliveryExecutionStateService->finish(Object(oat\taoDelivery\model\execution\DeliveryExecution))
#9 [internal function]: oat\ltiDeliveryProvider\controller\DeliveryRunner->finishDeliveryExecution()
#10 /var/www/html/tao/models/classes/routing/ActionEnforcer.php(145): call_user_func_array(Array, Array)
#11 /var/www/html/tao/models/classes/routing/TaoFrontController.php(89): oat\tao\model\routing\ActionEnforcer->execute()
#12 /var/www/html/tao/models/classes/mvc/Bootstrap.php(330): oat\tao\model\routing\TaoFrontController->legacy(Object(common_http_Request))
#13 /var/www/html/tao/models/classes/mvc/Bootstrap.php(172): oat\tao\model\mvc\Bootstrap->mvc()
#14 /var/www/html/tao/models/classes/mvc/Bootstrap.php(233): oat\tao\model\mvc\Bootstrap->dispatchHttp()
#15 /var/www/html/index.php(33): oat\tao\model\mvc\Bootstrap->dispatch()
#16 {main}
```

This PR aims to prevent the method to fails with some values in the parameters