### PR TITLE
Fix/tao 5361 persist extra time

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -44,7 +44,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '7.8.3',
+    'version' => '7.8.4',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=10.28.0',

--- a/model/execution/DeliveryExecutionManagerService.php
+++ b/model/execution/DeliveryExecutionManagerService.php
@@ -27,6 +27,7 @@ use oat\taoProctoring\model\implementation\TestSessionService;
 use oat\taoProctoring\model\monitorCache\DeliveryMonitoringData;
 use oat\taoProctoring\model\monitorCache\DeliveryMonitoringService;
 use oat\taoQtiTest\models\runner\session\TestSession;
+use oat\taoQtiTest\models\runner\StorageManager;
 use oat\taoQtiTest\models\runner\time\QtiTimer;
 use oat\taoQtiTest\models\runner\time\QtiTimerFactory;
 use qtism\common\datatypes\QtiDuration;
@@ -215,6 +216,7 @@ class DeliveryExecutionManagerService extends ConfigurableService
                 ->setExtraTime($extraTime)
                 ->setExtendedTime($extendedTime)
                 ->save();
+            $this->getServiceLocator()->get(StorageManager::SERVICE_ID)->persist();
 
 
             $data->update(DeliveryMonitoringService::EXTRA_TIME, $timer->getExtraTime());

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -510,6 +510,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('7.4.0');
         }
       
-        $this->skip('7.4.0', '7.8.3');
+        $this->skip('7.4.0', '7.8.4');
     }
 }


### PR DESCRIPTION
Related to: 
- https://oat-sa.atlassian.net/browse/TAO-5361
- https://oat-sa.atlassian.net/browse/TAO-5313

Since the refactoring of the ExtendedState, we must explicitly persist the data that should go to the state storage. The extra time feature has been ignored by this refactoring.