### PR TITLE
Fix/empty remaining time

### DIFF
--- a/helpers/DeliveryHelper.php
+++ b/helpers/DeliveryHelper.php
@@ -404,7 +404,7 @@ class DeliveryHelper
             }
 
             $extraTime = (isset($cachedData[DeliveryMonitoringService::EXTRA_TIME])) ? floatval($cachedData[DeliveryMonitoringService::EXTRA_TIME]) : 0;
-            $remaining  = (isset($cachedData[DeliveryMonitoringService::REMAINING_TIME])) ? $cachedData[DeliveryMonitoringService::REMAINING_TIME] : 0;
+            $remaining  = (isset($cachedData[DeliveryMonitoringService::REMAINING_TIME])) ? intval($cachedData[DeliveryMonitoringService::REMAINING_TIME]) : 0;
             $diffTimestamp = (isset($cachedData[DeliveryMonitoringService::DIFF_TIMESTAMP])) ? floatval($cachedData[DeliveryMonitoringService::DIFF_TIMESTAMP]) : 0;
             $duration = (isset($cachedData[DeliveryMonitoringService::ITEM_DURATION])) ? floatval($cachedData[DeliveryMonitoringService::ITEM_DURATION]) : 0;
             if (isset($cachedData[DeliveryMonitoringService::CONSTRAINTS_DURATION]) && $cachedData[DeliveryMonitoringService::CONSTRAINTS_DURATION]) {

--- a/manifest.php
+++ b/manifest.php
@@ -45,7 +45,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '7.11.5',
+    'version' => '7.11.6',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=14.4.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -537,6 +537,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('7.11.1');
         }
       
-        $this->skip('7.11.1', '7.11.5');
+        $this->skip('7.11.1', '7.11.6');
     }
 }


### PR DESCRIPTION
By some reasons remaining time value is empty string in the delivery monitoring table.