### PR TITLE
Fix/tao 6087 wrong status on reactivate

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -45,7 +45,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '8.5.4',
+    'version' => '8.5.5',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=15.7.0',

--- a/model/implementation/DeliveryExecutionStateService.php
+++ b/model/implementation/DeliveryExecutionStateService.php
@@ -514,10 +514,10 @@ class DeliveryExecutionStateService extends AbstractStateService implements \oat
             $testSessionService = $this->getServiceManager()->get(TestSessionService::SERVICE_ID);
             $session = $testSessionService->getTestSession($deliveryExecution);
             if ($session) {
-                $session->setState(AssessmentTestSessionState::INTERACTING);
+                $session->setState(AssessmentTestSessionState::SUSPENDED);
                 $testSessionService->persist($session);
             }
-            $this->setState($deliveryExecution, ProctoredDeliveryExecution::STATE_ACTIVE);
+            $this->setState($deliveryExecution, ProctoredDeliveryExecution::STATE_PAUSED);
 
             /** @var EventManager $eventManager */
             $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -619,6 +619,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('8.5.2');
         }
 
-        $this->skip('8.5.2', '8.5.4');
+        $this->skip('8.5.2', '8.5.5');
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-6087

When a delivery execution is re-activated, set its state to `paused` instead of `in progress`.

To check the fix, you will need:
- a proctored delivery
- a proctor with `Proctor Administrator` role

Then:
- start an execution as a TestTaker
- authorize it from the proctor's monitor page
- terminate the execution, either by exiting it or proctor terminate it
- once the TestTaker has been kicked out from the delivery, re-activate it from the proctor screen (action accessible from the administration column, button "Terminate/Reactivate and irregularity")
- you should see the new status of the delivery execution