### PR TITLE
TAO-7077 proctoring runner service fix

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -46,7 +46,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '12.2.0',
+    'version' => '12.3.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=21.0.0',

--- a/model/runner/ProctoringRunnerService.php
+++ b/model/runner/ProctoringRunnerService.php
@@ -26,7 +26,6 @@ use oat\taoQtiTest\models\runner\QtiRunnerPausedException;
 use oat\taoQtiTest\models\runner\QtiRunnerService;
 use oat\taoQtiTest\models\runner\RunnerServiceContext;
 use qtism\runtime\tests\AssessmentTestSessionState;
-use oat\taoQtiTest\models\SectionPauseService;
 
 /**
  * Class ProctoringRunnerService
@@ -50,11 +49,11 @@ class ProctoringRunnerService extends QtiRunnerService
      */
     public function getTestData(RunnerServiceContext $context)
     {
-        $couldBePaused = $this->getServiceManager()->get(SectionPauseService::SERVICE_ID)->couldBePaused($context->getTestSession());
+        $testContext = parent::getTestContext($context);
         $testData = parent::getTestData($context);
 
-        if (isset($couldBePaused)) {
-            $testData['securePauseStateRequired'] = $couldBePaused;
+        if (isset($testContext['options']) && isset($testContext['options']['sectionPause'])) {
+            $testData['securePauseStateRequired'] = $testContext['options']['sectionPause'];
         } else {
             if ($context->getTestExecutionUri()) {
                 $deliveryExecution = ServiceProxy::singleton()->getDeliveryExecution($context->getTestExecutionUri());

--- a/model/runner/ProctoringRunnerService.php
+++ b/model/runner/ProctoringRunnerService.php
@@ -26,6 +26,7 @@ use oat\taoQtiTest\models\runner\QtiRunnerPausedException;
 use oat\taoQtiTest\models\runner\QtiRunnerService;
 use oat\taoQtiTest\models\runner\RunnerServiceContext;
 use qtism\runtime\tests\AssessmentTestSessionState;
+use oat\taoQtiTest\models\SectionPauseService;
 
 /**
  * Class ProctoringRunnerService
@@ -49,11 +50,11 @@ class ProctoringRunnerService extends QtiRunnerService
      */
     public function getTestData(RunnerServiceContext $context)
     {
-        $testContext = parent::getTestContext($context);
+        $couldBePaused = $this->getServiceManager()->get(SectionPauseService::SERVICE_ID)->couldBePaused($context->getTestSession());
         $testData = parent::getTestData($context);
 
-        if (isset($testContext['options']) && isset($testContext['options']['sectionPause'])) {
-            $testData['securePauseStateRequired'] = $testContext['options']['sectionPause'];
+        if ($couldBePaused !== null) {
+            $testData['securePauseStateRequired'] = $couldBePaused;
         } else {
             if ($context->getTestExecutionUri()) {
                 $deliveryExecution = ServiceProxy::singleton()->getDeliveryExecution($context->getTestExecutionUri());

--- a/model/runner/ProctoringRunnerService.php
+++ b/model/runner/ProctoringRunnerService.php
@@ -26,6 +26,7 @@ use oat\taoQtiTest\models\runner\QtiRunnerPausedException;
 use oat\taoQtiTest\models\runner\QtiRunnerService;
 use oat\taoQtiTest\models\runner\RunnerServiceContext;
 use qtism\runtime\tests\AssessmentTestSessionState;
+use oat\taoQtiTest\models\SectionPauseService;
 
 /**
  * Class ProctoringRunnerService
@@ -49,11 +50,11 @@ class ProctoringRunnerService extends QtiRunnerService
      */
     public function getTestData(RunnerServiceContext $context)
     {
-        $testContext = parent::getTestContext($context);
+        $couldBePaused = $this->getServiceManager()->get(SectionPauseService::SERVICE_ID)->couldBePaused($context->getTestSession());
         $testData = parent::getTestData($context);
 
-        if (isset($testContext['options']) && isset($testContext['options']['sectionPause'])) {
-            $testData['securePauseStateRequired'] = $testContext['options']['sectionPause'];
+        if (isset($couldBePaused)) {
+            $testData['securePauseStateRequired'] = $couldBePaused;
         } else {
             if ($context->getTestExecutionUri()) {
                 $deliveryExecution = ServiceProxy::singleton()->getDeliveryExecution($context->getTestExecutionUri());

--- a/model/runner/ProctoringRunnerService.php
+++ b/model/runner/ProctoringRunnerService.php
@@ -39,7 +39,7 @@ class ProctoringRunnerService extends QtiRunnerService
     use OntologyAwareTrait;
 
     /**
-     * Get Test Context.
+     * Get Test Data.
      *
      * @param RunnerServiceContext $context
      * @return array
@@ -47,22 +47,23 @@ class ProctoringRunnerService extends QtiRunnerService
      * @throws \common_exception_NotFound
      * @throws \core_kernel_persistence_Exception
      */
-    public function getTestContext(RunnerServiceContext $context)
+    public function getTestData(RunnerServiceContext $context)
     {
-        $response = parent::getTestContext($context);
+        $testContext = parent::getTestContext($context);
+        $testData = parent::getTestData($context);
 
-        if (isset($response['options']) && isset($response['options']['sectionPause'])) {
-            $response['securePauseStateRequired'] = $response['options']['sectionPause'];
+        if (isset($testContext['options']) && isset($testContext['options']['sectionPause'])) {
+            $testData['securePauseStateRequired'] = $testContext['options']['sectionPause'];
         } else {
             if ($context->getTestExecutionUri()) {
                 $deliveryExecution = ServiceProxy::singleton()->getDeliveryExecution($context->getTestExecutionUri());
                 if ($this->isProctoredDelivery($deliveryExecution->getDelivery())) {
-                    $response['securePauseStateRequired'] = true;
+                    $testData['securePauseStateRequired'] = true;
                 }
             }
         }
 
-        return $response;
+        return $testData;
     }
 
     /**

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -774,6 +774,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('12.0.0');
         }
 
-        $this->skip('12.0.0', '12.2.0');
+        $this->skip('12.0.0', '12.3.0');
     }
 }


### PR DESCRIPTION
move securePauseStateRequired param from getTestContext method to getTestData for proctor
-runner service

Related PR's:
https://github.com/oat-sa/extension-tao-test-runner-plugins/pull/82
https://github.com/oat-sa/extension-tao-act/pull/1080