### PR TITLE
Feature/tao 7389/extend monitoring data with execution context

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -51,7 +51,7 @@ return array(
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=21.8.0',
-        'taoDelivery'    => '>=12.0.0',
+        'taoDelivery'    => '>=12.5.0',
         'taoDeliveryRdf' => '>=7.0.0',
         'taoTestTaker'   => '>=4.0.0',
         'taoQtiTest'     => '>=29.2.0',

--- a/manifest.php
+++ b/manifest.php
@@ -47,7 +47,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '12.6.1',
+    'version' => '12.7.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=21.8.0',

--- a/model/monitorCache/DeliveryMonitoringData.php
+++ b/model/monitorCache/DeliveryMonitoringData.php
@@ -55,7 +55,7 @@ interface DeliveryMonitoringData
     public function setDeliveryExecutionContext(DeliveryExecutionContextInterface $context);
 
     /**
-     * @return DeliveryExecutionContextInterface
+     * @return DeliveryExecutionContextInterface|null
      */
     public function getDeliveryExecutionContext();
 

--- a/model/monitorCache/DeliveryMonitoringData.php
+++ b/model/monitorCache/DeliveryMonitoringData.php
@@ -21,6 +21,8 @@
 
 namespace oat\taoProctoring\model\monitorCache;
 
+use oat\taoDelivery\model\execution\DeliveryExecutionContextInterface;
+use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
 use qtism\runtime\tests\AssessmentTestSession;
 use oat\taoDelivery\model\execution\DeliveryExecution;
 
@@ -34,11 +36,28 @@ use oat\taoDelivery\model\execution\DeliveryExecution;
  */
 interface DeliveryMonitoringData
 {
+    const PARAM_EXECUTION_CONTEXT = 'execution_context';
+
     /**
      * Set delivery execution
      * @param DeliveryExecution $deliveryExecution
      */
     public function setDeliveryExecution(DeliveryExecution $deliveryExecution);
+
+    /**
+     * @return DeliveryExecutionInterface
+     */
+    public function getDeliveryExecution();
+
+    /**
+     * @param DeliveryExecutionContextInterface $context
+     */
+    public function setDeliveryExecutionContext(DeliveryExecutionContextInterface $context);
+
+    /**
+     * @return DeliveryExecutionContextInterface
+     */
+    public function getDeliveryExecutionContext();
 
     /**
      * Set test session

--- a/model/monitorCache/implementation/DeliveryMonitoringData.php
+++ b/model/monitorCache/implementation/DeliveryMonitoringData.php
@@ -21,7 +21,8 @@
 
 namespace oat\taoProctoring\model\monitorCache\implementation;
 
-use oat\oatbox\service\ServiceManager;
+use oat\taoDelivery\model\execution\DeliveryExecutionContext;
+use oat\taoDelivery\model\execution\DeliveryExecutionContextInterface;
 use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
 use oat\taoProctoring\model\execution\DeliveryExecutionManagerService;
 use oat\taoProctoring\model\implementation\TestSessionService;
@@ -117,6 +118,34 @@ class DeliveryMonitoringData implements DeliveryMonitoringDataInterface, Service
     public function setDeliveryExecution(DeliveryExecution $deliveryExecution)
     {
         $this->deliveryExecution = $deliveryExecution;
+    }
+
+    /**
+     * @return DeliveryExecutionInterface
+     */
+    public function getDeliveryExecution()
+    {
+        return $this->deliveryExecution;
+    }
+
+    /**
+     * {@inheritdoc
+     */
+    public function setDeliveryExecutionContext(DeliveryExecutionContextInterface $context)
+    {
+        $this->update(self::PARAM_EXECUTION_CONTEXT, json_encode($context));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDeliveryExecutionContext()
+    {
+        if (isset($this->data[self::PARAM_EXECUTION_CONTEXT])) {
+            return DeliveryExecutionContext::createFromArray(json_decode($this->data[self::PARAM_EXECUTION_CONTEXT], true));
+        }
+
+        return false;
     }
 
     /**

--- a/model/monitorCache/implementation/DeliveryMonitoringData.php
+++ b/model/monitorCache/implementation/DeliveryMonitoringData.php
@@ -129,7 +129,7 @@ class DeliveryMonitoringData implements DeliveryMonitoringDataInterface, Service
     }
 
     /**
-     * {@inheritdoc
+     * {@inheritdoc}
      */
     public function setDeliveryExecutionContext(DeliveryExecutionContextInterface $context)
     {
@@ -141,11 +141,13 @@ class DeliveryMonitoringData implements DeliveryMonitoringDataInterface, Service
      */
     public function getDeliveryExecutionContext()
     {
-        if (isset($this->data[self::PARAM_EXECUTION_CONTEXT])) {
-            return DeliveryExecutionContext::createFromArray(json_decode($this->data[self::PARAM_EXECUTION_CONTEXT], true));
-        }
+        try {
+            if (isset($this->data[self::PARAM_EXECUTION_CONTEXT])) {
+                return DeliveryExecutionContext::createFromArray(json_decode($this->data[self::PARAM_EXECUTION_CONTEXT], true));
+            }
+        } catch (\Exception $e) {}
 
-        return false;
+        return null;
     }
 
     /**

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -31,7 +31,6 @@ use oat\tao\model\accessControl\func\AccessRule;
 use oat\tao\model\accessControl\func\AclProxy;
 use oat\tao\model\event\MetadataModified;
 use oat\tao\model\mvc\DefaultUrlService;
-use oat\tao\model\taskQueue\Event\TaskLogArchivedEvent;
 use oat\tao\model\taskQueue\TaskLogInterface;
 use oat\tao\model\user\import\UserCsvImporterFactory;
 use oat\tao\model\user\TaoRoles;
@@ -39,7 +38,6 @@ use oat\tao\scripts\update\OntologyUpdater;
 use oat\taoDelivery\model\AssignmentService;
 use oat\taoDelivery\model\execution\StateServiceInterface;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionCreated;
-use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionReactivated;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState;
 use oat\taoDeliveryRdf\model\Delete\DeliveryDeleteService;
 use oat\taoDeliveryRdf\model\event\DeliveryCreatedEvent;
@@ -842,6 +840,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('12.5.3');
         }
 
-        $this->skip('12.5.3', '12.6.1');
+        $this->skip('12.5.3', '12.7.0');
     }
 }

--- a/test/integration/monitorCache/DeliveryMonitoringDataTest.php
+++ b/test/integration/monitorCache/DeliveryMonitoringDataTest.php
@@ -167,14 +167,18 @@ class DeliveryMonitoringDataTest extends TaoPhpUnitTestRunner
     {
         $result = $this->object->getDeliveryExecutionContext();
 
-        $this->assertFalse($result, 'Method must return false if context does not exist.');
+        $this->assertNull($result, 'Method must return false if context does not exist.');
     }
 
-    public function testDetDeliveryExecutionContext()
+    public function testGetDeliveryExecutionContext()
     {
+        $contextData = [
+            'execution_id' => 'http://test-execution-uri.dev',
+            'context_id' => 'test_context_id',
+        ];
         $this->deliveryExecutionContextMock->expects($this->once())
             ->method('jsonSerialize')
-            ->willReturn([]);
+            ->willReturn($contextData);
 
         $this->object->setDeliveryExecutionContext($this->deliveryExecutionContextMock);
 

--- a/test/integration/monitorCache/mock/DeliveryMonitoringData.php
+++ b/test/integration/monitorCache/mock/DeliveryMonitoringData.php
@@ -145,7 +145,7 @@ class DeliveryMonitoringData implements DeliveryMonitoringDataInterface
             return DeliveryExecutionContext::createFromArray($this->data[self::PARAM_EXECUTION_CONTEXT]);
         }
 
-        return false;
+        return null;
     }
 
     /**

--- a/test/integration/monitorCache/mock/DeliveryMonitoringData.php
+++ b/test/integration/monitorCache/mock/DeliveryMonitoringData.php
@@ -21,6 +21,9 @@
 
 namespace oat\taoProctoring\test\integration\monitorCache\mock;
 
+use oat\taoDelivery\model\execution\DeliveryExecutionContext;
+use oat\taoDelivery\model\execution\DeliveryExecutionContextInterface;
+use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
 use oat\taoProctoring\model\monitorCache\DeliveryMonitoringData as DeliveryMonitoringDataInterface;
 use oat\taoProctoring\model\monitorCache\DeliveryMonitoringService;
 use oat\oatbox\service\ServiceManager;
@@ -43,7 +46,7 @@ class DeliveryMonitoringData implements DeliveryMonitoringDataInterface
     private $data = [];
 
     /**
-     * @var DeliveryExecution
+     * @var DeliveryExecutionInterface
      */
     private $deliveryExecution;
 
@@ -115,6 +118,34 @@ class DeliveryMonitoringData implements DeliveryMonitoringDataInterface
     public function setDeliveryExecution(DeliveryExecution $deliveryExecution)
     {
         $this->deliveryExecution = $deliveryExecution;
+    }
+
+    /**
+     * @return DeliveryExecutionInterface
+     */
+    public function getDeliveryExecution()
+    {
+        return $this->deliveryExecution;
+    }
+
+    /**
+     * {@inheritdoc
+     */
+    public function setDeliveryExecutionContext(DeliveryExecutionContextInterface $context)
+    {
+        $this->data->update(self::PARAM_EXECUTION_CONTEXT, json_encode($context));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDeliveryExecutionContext()
+    {
+        if (isset($this->data[self::PARAM_EXECUTION_CONTEXT])) {
+            return DeliveryExecutionContext::createFromArray($this->data[self::PARAM_EXECUTION_CONTEXT]);
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
Store delivery execution context data in delivery monitoring data.

Requires: 
https://github.com/oat-sa/extension-tao-delivery/pull/385
https://github.com/oat-sa/extension-tao-lti/pull/174