### PR TITLE
Fixed failing nightly build test

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -47,7 +47,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '12.6.1',
+    'version' => '12.6.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=21.8.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -842,6 +842,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('12.5.3');
         }
 
-        $this->skip('12.5.3', '12.6.1');
+        $this->skip('12.5.3', '12.6.2');
     }
 }

--- a/test/unit/model/ActivityMonitoringServiceTest.php
+++ b/test/unit/model/ActivityMonitoringServiceTest.php
@@ -38,25 +38,23 @@ class ActivityMonitoringServiceTest extends TestCase
 
         $timeKeys = $service->getTimeKeys(new \DateInterval('PT1M'), clone($date));
         $this->assertEquals(60, count($timeKeys));
-        $this->assertEquals($date->format('i')+1, $timeKeys[0]->format('i'));
+        $this->assertEquals($date->format('i') + 1, $timeKeys[0]->format('i'));
         $this->assertEquals(0, $timeKeys[0]->format('s'));
-
 
         $timeKeys = $service->getTimeKeys(new \DateInterval('PT1H'), clone($date));
         $this->assertEquals(24, count($timeKeys));
-        $this->assertEquals($date->format('h')+1, $timeKeys[0]->format('h'));
+        $this->assertEquals($date->format('h') + 1, $timeKeys[0]->format('h'));
         $this->assertEquals(0, $timeKeys[0]->format('i'));
 
-
         $timeKeys = $service->getTimeKeys(new \DateInterval('P1D'), clone($date));
-        $this->assertEquals(cal_days_in_month(CAL_GREGORIAN, $date->format('m'), $date->format('Y')), count($timeKeys));
-        $this->assertEquals($date->format('d')+1, $timeKeys[0]->format('d'));
+        $tomorrow = (new \DateTime('now', new \DateTimeZone('UTC')))->add(new \DateInterval('P1D'));
+        $this->assertEquals($tomorrow->format('t'), count($timeKeys));
+        $this->assertEquals($tomorrow->format('d'), $timeKeys[0]->format('d'));
         $this->assertEquals('00', $timeKeys[0]->format('H'));
-
 
         $timeKeys = $service->getTimeKeys(new \DateInterval('P1M'), clone($date));
         $this->assertEquals(12, count($timeKeys));
-        $this->assertEquals($date->format('m')+1, $timeKeys[0]->format('m'));
+        $this->assertEquals($date->format('m') + 1, $timeKeys[0]->format('m'));
         $this->assertEquals(0, $timeKeys[0]->format('H'));
         $this->assertEquals('01', $timeKeys[0]->format('d'));
     }


### PR DESCRIPTION
Basically, the test was asserting that the number of days in the month of today equals the number of days of the month of tomorrow, which should fail on last day of every month (except 31 of July, obviously).

Still, this fixes the test but not the code. I'm not sure what the goal of the code is: when requesting for timekeys for the month, (e.g. March has 31 days), we get timekeys from 1st of march and 31 days back, to january 30...
The count of days is good (31), but we don't cover the february month...

Note:
```cal_days_in_month(CAL_GREGORIAN, $date->format('m'), $date->format('Y'))```
can be advantageously replaced with
```$date->format('t')```