### PR TITLE
Fix/tao 8209 glitch in datatable

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -47,7 +47,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '12.9.1',
+    'version' => '12.9.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=32.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -840,6 +840,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('12.5.3');
         }
 
-        $this->skip('12.5.3', '12.9.1');
+        $this->skip('12.5.3', '12.9.2');
     }
 }

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -580,6 +580,14 @@ define([
                     });
                 }
 
+                /**
+                 * Return the default date range of one day
+                 * @returns {string}
+                 */
+                function getDefaultStartTimeFilter() {
+                    return moment().format('L') + ' to ' + moment().add('1', 'd').format('L');
+                }
+
                 if (deliveryId) {
                     serviceParams.delivery = deliveryId;
                 }
@@ -812,25 +820,23 @@ define([
                                 // the date time picker won't display otherwise
                                 $filterContainer.css('position', 'static');
 
+                                if(startDatePicker){
+                                    startDatePicker.destroy();
+                                }
+
                                 startDatePicker = dateTimePicker($filterContainer, {
                                     setup : 'date-range',
                                     format : dateFormatStr,
                                     replaceField : $elt[0]
                                 })
-                                .on('ready', function(){
-                                    if(initialValue){
-                                        this.setValue([new Date(), moment().add('1', 'd').toDate()]);
-                                        $list.datatable('filter');
-                                    }
-                                })
-                                .on('change', function(value){
-                                    var selection = this.getSelectedDates();
-                                    if ( (value === '' && lastValue !== value) ||
-                                         (selection && selection.length === 2)) {
-                                        $list.datatable('filter');
-                                    }
-                                    lastValue = value;
-                                });
+                                    .on('change', function(value){
+                                        var selection = this.getSelectedDates();
+                                        if ( (value === '' && lastValue !== value) ||
+                                            (selection && selection.length === 2)) {
+                                            $list.datatable('filter');
+                                        }
+                                        lastValue = value;
+                                    });
                             }
                         },
                     });
@@ -1092,6 +1098,7 @@ define([
                             },
                             filterStrategy: 'multiple',
                             filterSelector: 'select, input:not(.select2-input, .select2-focusser)',
+                            filtercolumns: {start_time: getDefaultStartTimeFilter()},
                             filter: true,
                             tools: tools,
                             model: model,


### PR DESCRIPTION
### Ticket: 

https://oat-sa.atlassian.net/browse/TAO-8209

### Summary

When opening the Proctor screen as an External user, the proctor screen loads lots of data to the Datagrid and then sorts the data.

### How to reproduce the issue?

Log in to the testing system as an external user on a day that no testing has occurred, and select a child organization (TU, ATEF, ATU). click the Proctor button. The page will display data and then will reset the table.

![fnL91mxpUb](https://user-images.githubusercontent.com/4357095/57063906-13ea7380-6cc5-11e9-906a-020f32f40b94.gif)


### How did I fix the issue?

Instead of selecting the default date range once the date picker is initialised I pass the default date range in the data table init config which removes the glitch.
