### PR TITLE
registrer DeliveryMonitoring storage in DeliveryExecutionDeleteService

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -47,7 +47,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '13.0.0',
+    'version' => '13.1.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=34.0.0',
@@ -92,7 +92,8 @@ return array(
             \oat\taoProctoring\scripts\install\SetupProctorCsvImporter::class,
             \oat\taoProctoring\scripts\install\RegisterProctorAttemptService::class,
             RegisterProctoringDeliveryDeleteService::class,
-            SetUpQueueTasks::class
+            SetUpQueueTasks::class,
+            \oat\taoProctoring\scripts\install\RegisterDeleteDeliveryExecution::class,
         ),
         'rdf' => array(
             __DIR__.DIRECTORY_SEPARATOR.'scripts'.DIRECTORY_SEPARATOR.'install'.DIRECTORY_SEPARATOR.'proctoring.rdf'

--- a/scripts/install/RegisterDeleteDeliveryExecution.php
+++ b/scripts/install/RegisterDeleteDeliveryExecution.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA;
+ *
+ *
+ */
+namespace oat\taoProctoring\scripts\install;
+
+use oat\oatbox\extension\InstallAction;
+use oat\taoDelivery\model\execution\Delete\DeliveryExecutionDeleteService;
+
+class RegisterDeleteDeliveryExecution extends InstallAction
+{
+    /**
+     * @param $params
+     * @throws \common_Exception
+     * @throws \oat\oatbox\service\exception\InvalidServiceManagerException
+     */
+    public function __invoke($params)
+    {
+        /** @var DeliveryExecutionDeleteService $executionDeleteService */
+        $executionDeleteService = $this->getServiceLocator()->get(DeliveryExecutionDeleteService::SERVICE_ID);
+        $previousServices       = $executionDeleteService->getOption(DeliveryExecutionDeleteService::OPTION_DELETE_DELIVERY_EXECUTION_DATA_SERVICES);
+
+        $executionDeleteService->setOption(DeliveryExecutionDeleteService::OPTION_DELETE_DELIVERY_EXECUTION_DATA_SERVICES,
+            array_merge($previousServices, [
+                'taoProctoring/DeliveryLog',
+                'taoProctoring/DeliveryMonitoring',
+            ])
+        );
+
+        $this->getServiceManager()->register(DeliveryExecutionDeleteService::SERVICE_ID, $executionDeleteService);
+    }
+
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -91,6 +91,7 @@ use oat\taoProctoring\model\execution\DeliveryExecution as ProctoredDeliveryExec
 use oat\taoProctoring\model\AssessmentResultsService;
 use oat\taoProctoring\model\execution\Counter\DeliveryExecutionCounterService;
 use oat\taoDelivery\model\execution\Counter\DeliveryExecutionCounterInterface;
+use oat\taoDelivery\model\execution\Delete\DeliveryExecutionDeleteService;
 
 /**
  *
@@ -841,5 +842,23 @@ class Updater extends common_ext_ExtensionUpdater
         }
 
         $this->skip('12.5.3', '13.0.0');
+
+        if ($this->isVersion('13.0.0')) {
+            /** @var DeliveryExecutionDeleteService $executionDeleteService */
+            $executionDeleteService = $this->getServiceManager()->get(DeliveryExecutionDeleteService::SERVICE_ID);
+            $previousServices       = $executionDeleteService->getOption(DeliveryExecutionDeleteService::OPTION_DELETE_DELIVERY_EXECUTION_DATA_SERVICES);
+
+            $executionDeleteService->setOption(DeliveryExecutionDeleteService::OPTION_DELETE_DELIVERY_EXECUTION_DATA_SERVICES,
+                array_merge($previousServices, [
+                    'taoProctoring/DeliveryLog',
+                    'taoProctoring/DeliveryMonitoring',
+                ])
+            );
+
+            $this->getServiceManager()->register(DeliveryExecutionDeleteService::SERVICE_ID, $executionDeleteService);
+
+            $this->setVersion('13.1.0');
+        }
+
     }
 }


### PR DESCRIPTION
When taoProctoring installed `DeliveryMonitoring` storage is not registered in `taoDelivery/DeliveryExecutionDelete` service.

steps to reproduce:
1. install tao and taoProctoring extension
2. finish one test
3. try to delete delivery. `DeliveryDeleteTask` will add itself to the queue again and again because delivery execution is not deleted from `DeliveryMonitoring` storage