### PR TITLE
clipboard cleaner improved (now it works with ipad)

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -47,10 +47,10 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '13.1.0',
+    'version' => '13.2.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
-        'tao'            => '>=34.0.0',
+        'tao'            => '>=35.3.0',
         'taoDelivery'    => '>=12.5.0',
         'taoDeliveryRdf' => '>=7.0.0',
         'taoTestTaker'   => '>=4.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -860,5 +860,7 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('13.1.0');
         }
 
+        $this->skip('13.1.0', '13.2.0');
+
     }
 }

--- a/views/js/controller/DeliveryServer/awaiting.js
+++ b/views/js/controller/DeliveryServer/awaiting.js
@@ -31,8 +31,9 @@ define([
     'util/url',
     'ui/dialog/confirm',
     'tpl!taoProctoring/templates/deliveryServer/authorizationSuccess',
-    'tpl!taoProctoring/templates/deliveryServer/authorizationListBoxActions'
-], function (_, $, __, helpers, loadingBar, listBox, dialogAlert, polling, keepAfterResume, url, dialogConfirm, authSuccessTpl, listBoxActionsTpl){
+    'tpl!taoProctoring/templates/deliveryServer/authorizationListBoxActions',
+    'util/clipboard'
+], function (_, $, __, helpers, loadingBar, listBox, dialogAlert, polling, keepAfterResume, url, dialogConfirm, authSuccessTpl, listBoxActionsTpl, clipboard){
     'use strict';
 
     /**
@@ -46,43 +47,6 @@ define([
      * @type {String}
      */
     var cssScope = '.awaiting-authorization';
-
-    /**
-     * Nothing needs to be taken to system clipboard on proceed action
-     */
-    var cleanClipboard = function cleanClipboard () {
-        var textToClipboard = ' ';
-        var selected;
-        var success;
-        var textAreaToSelContent;
-        if (window.clipboardData) { // Internet Explorer
-            window.clipboardData.setData ("Text", textToClipboard);
-        } else {
-            textAreaToSelContent = document.createElement('textarea');  // Create a <textarea> element
-            textAreaToSelContent.setAttribute("id", "clipboardCleanerPlugin");
-            textAreaToSelContent.value = textToClipboard;                                 // Set its value to the string that you want copied
-            textAreaToSelContent.setAttribute('readonly', '');                // Make it readonly to be tamper-proof
-            textAreaToSelContent.style.position = 'absolute';
-            textAreaToSelContent.style.left = '-9999px';                      // Move outside the screen to make it invisible
-            document.body.appendChild(textAreaToSelContent);                  // Append the <textarea> element to the HTML document
-            selected =
-                document.getSelection().rangeCount > 0        // Check if there is any content selected previously
-                    ? document.getSelection().getRangeAt(0)     // Store selection if found
-                    : false;                               // Mark as false to know no selection existed before
-            textAreaToSelContent.select();                                   // Select the <textarea> content
-            success = document.execCommand('copy');   // Copy - only works as a result of a user action (e.g. click events)
-
-            if (!success) {
-                throw new Error('Clipboard can not be cleaned');
-            }
-
-            document.body.removeChild(textAreaToSelContent);                  // Remove the <textarea> element
-            if (selected) {                                 // If a selection existed before copying
-                document.getSelection().removeAllRanges();    // Unselect everything on the HTML document
-                document.getSelection().addRange(selected);   // Restore the original selection
-            }
-        }
-    };
 
     /**
      * Controls the ProctorDelivery index page
@@ -119,7 +83,7 @@ define([
             var deliveryStarted = false;
             var runDelivery = function runDelivery () {
                 loadingBar.start();
-                cleanClipboard();
+                clipboard.clean();
                 deliveryStarted = true;
                 window.location.href = runDeliveryUrl;
             };


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-7852

- [x] https://github.com/oat-sa/tao-core/pull/2125

On the test launching with lti tool - clipboard is clean (has space instead of any content)
Improvement (now it works with iPad)