### PR TITLE
Do not use test taker role by default

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -47,7 +47,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '16.0.0',
+    'version' => '16.0.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=36.0.0',

--- a/model/implementation/TestSessionHistoryService.php
+++ b/model/implementation/TestSessionHistoryService.php
@@ -323,7 +323,13 @@ class TestSessionHistoryService extends ConfigurableService implements TestSessi
     {
         $userService = \tao_models_classes_UserService::singleton();
         if (!isset($this->authorRoles[$user->getUri()])) {
-            $this->authorRoles[$user->getUri()] = ($userService->userHasRoles($user, $this->proctorRoles)) ? __('Proctor') : __('Test-Taker');
+            $userRole = '';
+            $allUserRoles = $userService->getUserRoles($user);
+            if (!empty($allUserRoles)) {
+                $userRole = $userService->userHasRoles($user, $this->proctorRoles) ? __('Proctor') : __('Test-Taker');
+            }
+
+            $this->authorRoles[$user->getUri()] = $userRole;
         }
         return $this->authorRoles[$user->getUri()];
     }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -866,5 +866,7 @@ class Updater extends common_ext_ExtensionUpdater
             OntologyUpdater::syncModels();
             $this->setVersion('16.0.0');
         }
+
+        $this->skip('16.0.0', '16.0.1');
     }
 }


### PR DESCRIPTION
Issue: https://oat-sa.atlassian.net/browse/TAO-8581
Issue should be fixed by this PR https://github.com/oat-sa/extension-lti-proctoring/pull/120.

The goal of this modification is to do not use `Test Taker` role by default for all events which were not performed by proctor.

To test: 
1. Start delivery execution via LTI.
2. Pause execution from proctor screen.
3. Terminate execution using CLI action `taoProctoring/scripts/TerminatePausedAssessment.php`
4. Go to proctor screen and try to open detailed view for terminated session