### PR TITLE
Fixed test for time keys increment casted to regular number of seconds, hours or months.

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -48,7 +48,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '17.2.0',
+    'version' => '17.2.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=38.9.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -901,6 +901,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('17.0.0');
         }
 
-        $this->skip('17.0.0', '17.2.0');
+        $this->skip('17.0.0', '17.2.1');
     }
 }

--- a/test/unit/model/ActivityMonitoringServiceTest.php
+++ b/test/unit/model/ActivityMonitoringServiceTest.php
@@ -38,12 +38,12 @@ class ActivityMonitoringServiceTest extends TestCase
 
         $timeKeys = $service->getTimeKeys(new \DateInterval('PT1M'), clone($date));
         $this->assertEquals(60, count($timeKeys));
-        $this->assertEquals(((int)$date->format('i') + 1) % 60, $timeKeys[0]->format('i'));
+        $this->assertEquals(((int)$date->format('i') + 1) % 60, (int)$timeKeys[0]->format('i'));
         $this->assertEquals(0, $timeKeys[0]->format('s'));
 
         $timeKeys = $service->getTimeKeys(new \DateInterval('PT1H'), clone($date));
         $this->assertEquals(24, count($timeKeys));
-        $this->assertEquals(((int)$date->format('H') + 1) % 24, $timeKeys[0]->format('H'));
+        $this->assertEquals(((int)$date->format('H') + 1) % 24, (int)$timeKeys[0]->format('H'));
         $this->assertEquals(0, $timeKeys[0]->format('i'));
 
         $timeKeys = $service->getTimeKeys(new \DateInterval('P1D'), clone($date));
@@ -54,7 +54,7 @@ class ActivityMonitoringServiceTest extends TestCase
 
         $timeKeys = $service->getTimeKeys(new \DateInterval('P1M'), clone($date));
         $this->assertEquals(12, count($timeKeys));
-        $this->assertEquals((int)$date->format('m') % 12 + 1, $timeKeys[0]->format('m'));
+        $this->assertEquals((int)$date->format('m') % 12 + 1, (int)$timeKeys[0]->format('m'));
         $this->assertEquals(0, $timeKeys[0]->format('H'));
         $this->assertEquals('01', $timeKeys[0]->format('d'));
     }

--- a/test/unit/model/ActivityMonitoringServiceTest.php
+++ b/test/unit/model/ActivityMonitoringServiceTest.php
@@ -43,7 +43,7 @@ class ActivityMonitoringServiceTest extends TestCase
 
         $timeKeys = $service->getTimeKeys(new \DateInterval('PT1H'), clone($date));
         $this->assertEquals(24, count($timeKeys));
-        $this->assertEquals(((int)$date->format('h') + 1) % 24, $timeKeys[0]->format('h'));
+        $this->assertEquals(((int)$date->format('H') + 1) % 24, $timeKeys[0]->format('H'));
         $this->assertEquals(0, $timeKeys[0]->format('i'));
 
         $timeKeys = $service->getTimeKeys(new \DateInterval('P1D'), clone($date));
@@ -54,7 +54,7 @@ class ActivityMonitoringServiceTest extends TestCase
 
         $timeKeys = $service->getTimeKeys(new \DateInterval('P1M'), clone($date));
         $this->assertEquals(12, count($timeKeys));
-        $this->assertEquals(((int)$date->format('m') + 1) % 12, $timeKeys[0]->format('m'));
+        $this->assertEquals((int)$date->format('m') % 12 + 1, $timeKeys[0]->format('m'));
         $this->assertEquals(0, $timeKeys[0]->format('H'));
         $this->assertEquals('01', $timeKeys[0]->format('d'));
     }

--- a/test/unit/model/ActivityMonitoringServiceTest.php
+++ b/test/unit/model/ActivityMonitoringServiceTest.php
@@ -38,12 +38,12 @@ class ActivityMonitoringServiceTest extends TestCase
 
         $timeKeys = $service->getTimeKeys(new \DateInterval('PT1M'), clone($date));
         $this->assertEquals(60, count($timeKeys));
-        $this->assertEquals($date->format('i') + 1, $timeKeys[0]->format('i'));
+        $this->assertEquals(((int)$date->format('i') + 1) % 60, $timeKeys[0]->format('i'));
         $this->assertEquals(0, $timeKeys[0]->format('s'));
 
         $timeKeys = $service->getTimeKeys(new \DateInterval('PT1H'), clone($date));
         $this->assertEquals(24, count($timeKeys));
-        $this->assertEquals($date->format('h') + 1, $timeKeys[0]->format('h'));
+        $this->assertEquals(((int)$date->format('h') + 1) % 24, $timeKeys[0]->format('h'));
         $this->assertEquals(0, $timeKeys[0]->format('i'));
 
         $timeKeys = $service->getTimeKeys(new \DateInterval('P1D'), clone($date));
@@ -54,7 +54,7 @@ class ActivityMonitoringServiceTest extends TestCase
 
         $timeKeys = $service->getTimeKeys(new \DateInterval('P1M'), clone($date));
         $this->assertEquals(12, count($timeKeys));
-        $this->assertEquals($date->format('m') + 1, $timeKeys[0]->format('m'));
+        $this->assertEquals(((int)$date->format('m') + 1) % 12, $timeKeys[0]->format('m'));
         $this->assertEquals(0, $timeKeys[0]->format('H'));
         $this->assertEquals('01', $timeKeys[0]->format('d'));
     }


### PR DESCRIPTION
When trying to increment DateTime for 1 second, 1 hour or 1 day, cast the new value to:
- 00-59 for seconds
- 00-23 for hours
- 01-12 for months (modulo before increment to get 1 based)