### PR TITLE
Fix/tao 9100/add option setStartDataOneDay and filter table bu clean start data

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -48,7 +48,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '17.2.3',
+    'version' => '17.3.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=38.9.0',

--- a/model/GuiSettingsService.php
+++ b/model/GuiSettingsService.php
@@ -76,6 +76,8 @@ class GuiSettingsService extends ConfigurableService
 
     const OPTION_SHOW_ACTION_SHOW_HISTORY = 'showActionShowHistory';
 
+    const OPTION_SET_START_DATA_ONE_DAY = 'setStartDataOneDay';
+
     /**
      * @return array
      */
@@ -93,6 +95,7 @@ class GuiSettingsService extends ConfigurableService
             self::OPTION_SHOW_COLUMN_EXTENDED_TIME  => $this->hasOption(self::OPTION_SHOW_COLUMN_EXTENDED_TIME) ? $this->getOption(self::OPTION_SHOW_COLUMN_EXTENDED_TIME) : true,
             self::OPTION_SHOW_COLUMN_CONNECTIVITY   => $this->hasOption(self::OPTION_SHOW_COLUMN_CONNECTIVITY) ? $this->getOption(self::OPTION_SHOW_COLUMN_CONNECTIVITY) : false,
             self::OPTION_SHOW_ACTION_SHOW_HISTORY   => $this->hasOption(self::OPTION_SHOW_ACTION_SHOW_HISTORY) ? $this->getOption(self::OPTION_SHOW_ACTION_SHOW_HISTORY) : true,
+            self::OPTION_SET_START_DATA_ONE_DAY     => $this->hasOption(self::OPTION_SET_START_DATA_ONE_DAY) ? $this->getOption(self::OPTION_SET_START_DATA_ONE_DAY) : true,
         ];
     }
 }

--- a/scripts/install/RegisterGuiSettingsService.php
+++ b/scripts/install/RegisterGuiSettingsService.php
@@ -44,7 +44,12 @@ class RegisterGuiSettingsService extends InstallAction
              */
             GuiSettingsService::PROCTORING_AUTO_REFRESH => 0,
 
-            GuiSettingsService::PROCTORING_ALLOW_PAUSE => true
+            GuiSettingsService::PROCTORING_ALLOW_PAUSE => true,
+
+            /**
+             * With start data range og one day
+             */
+            GuiSettingsService::OPTION_SET_START_DATA_ONE_DAY => true
         ]);
 
         $service->setServiceManager($this->getServiceManager());

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -901,6 +901,14 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('17.0.0');
         }
 
-        $this->skip('17.0.0', '17.3.0');
+        $this->skip('17.0.0', '17.2.3');
+
+        if ($this->isVersion('17.2.3')) {
+            /** @var GuiSettingsService $guiService */
+            $guiService = $this->getServiceManager()->get(GuiSettingsService::SERVICE_ID);
+            $guiService->setOption(GuiSettingsService::OPTION_SET_START_DATA_ONE_DAY, true);
+            $this->getServiceManager()->register(GuiSettingsService::SERVICE_ID, $guiService);
+            $this->setVersion('17.3.0');
+        }
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -901,6 +901,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('17.0.0');
         }
 
-        $this->skip('17.0.0', '17.2.3');
+        $this->skip('17.0.0', '17.3.0');
     }
 }

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -635,7 +635,7 @@ define([
                     var showColumnExtendedTime = extractOption(data, 'showColumnExtendedTime', true);
                     var showActionShowHistory = extractOption(data, 'showActionShowHistory', true);
                     var setStartDataOneDay = extractOption(data, 'setStartDataOneDay', true);
-                    
+
                     if (deliveryId) {
                         serviceParams.delivery = deliveryId;
                     }
@@ -866,6 +866,9 @@ define([
                                             $list.datatable('filter');
                                         }
                                         lastValue = value;
+                                    })
+                                    .on('clear', function () {
+                                        $list.datatable('filter');
                                     });
                             }
                         },

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -634,7 +634,8 @@ define([
                     var showColumnRemainingTime = extractOption(data, 'showColumnRemainingTime', true);
                     var showColumnExtendedTime = extractOption(data, 'showColumnExtendedTime', true);
                     var showActionShowHistory = extractOption(data, 'showActionShowHistory', true);
-
+                    var setStartDataOneDay = extractOption(data, 'setStartDataOneDay', true);
+                    
                     if (deliveryId) {
                         serviceParams.delivery = deliveryId;
                     }
@@ -1138,7 +1139,7 @@ define([
                             },
                             filterStrategy: 'multiple',
                             filterSelector: 'select, input:not(.select2-input, .select2-focusser)',
-                            filtercolumns: {start_time: getDefaultStartTimeFilter()},
+                            filtercolumns: {start_time: (setStartDataOneDay ? getDefaultStartTimeFilter() : "")},
                             filter: true,
                             tools: tools,
                             model: model,


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-9100

Added option setStartDataOneDay to GuiSettingsService.
By default setStartDataOneDay=true and filter will be set on data range of one day
Added handler on `clean` event, to apply datatable filter

Related to https://github.com/oat-sa/extension-tao-depp/pull/186