### PR TITLE
add ACTIVE delivery execution state to state check

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -48,7 +48,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '18.2.0',
+    'version' => '18.2.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=38.9.0',

--- a/model/authorization/TestTakerAuthorizationService.php
+++ b/model/authorization/TestTakerAuthorizationService.php
@@ -121,7 +121,7 @@ class TestTakerAuthorizationService extends ConfigurableService implements TestT
      */
     public function isActiveUnSecureDelivery($deliveryId, $state)
     {
-        return $this->isNotSecure($deliveryId) && $state === DeliveryExecutionInterface::STATE_ACTIVE;
+        return $state === DeliveryExecutionInterface::STATE_ACTIVE && !$this->isSecure($deliveryId);
     }
 
     /**
@@ -129,7 +129,7 @@ class TestTakerAuthorizationService extends ConfigurableService implements TestT
      * @return bool
      * @throws common_Exception
      */
-    private function isNotSecure($deliveryId)
+    private function isSecure($deliveryId)
     {
         $delivery = $this->getResource($deliveryId);
         $activeFeatures = explode(
@@ -138,7 +138,7 @@ class TestTakerAuthorizationService extends ConfigurableService implements TestT
                 $this->getProperty(DeliveryContainerService::TEST_RUNNER_FEATURES_PROPERTY)
             )
         );
-        return !in_array('security', $activeFeatures);
+        return in_array('security', $activeFeatures);
     }
 
     /**

--- a/model/authorization/TestTakerAuthorizationService.php
+++ b/model/authorization/TestTakerAuthorizationService.php
@@ -72,7 +72,7 @@ class TestTakerAuthorizationService extends ConfigurableService implements TestT
     public function verifyResumeAuthorization(DeliveryExecutionInterface $deliveryExecution, User $user)
     {
         $state = $deliveryExecution->getState()->getUri();
-        $deliveryUri= $deliveryExecution->getDelivery()->getUri();
+
         if (in_array($state, [
             ProctoredDeliveryExecution::STATE_FINISHED,
             ProctoredDeliveryExecution::STATE_CANCELED,
@@ -83,7 +83,7 @@ class TestTakerAuthorizationService extends ConfigurableService implements TestT
                 'Terminated/Finished delivery execution "'.$deliveryExecution->getIdentifier().'" cannot be resumed'
             );
         }
-
+        $deliveryUri= $deliveryExecution->getDelivery()->getUri();
         if (
             $this->isProctored($deliveryUri, $user)
             && $state !== ProctoredDeliveryExecution::STATE_AUTHORIZED

--- a/model/authorization/TestTakerAuthorizationService.php
+++ b/model/authorization/TestTakerAuthorizationService.php
@@ -80,7 +80,13 @@ class TestTakerAuthorizationService extends ConfigurableService implements TestT
                 'Terminated/Finished delivery execution "'.$deliveryExecution->getIdentifier().'" cannot be resumed'
             );
         }
-        if ($this->isProctored($deliveryExecution->getDelivery()->getUri(), $user) && $state !== ProctoredDeliveryExecution::STATE_AUTHORIZED) {
+        if (
+            $this->isProctored($deliveryExecution->getDelivery()->getUri(), $user)
+            && !in_array(
+                $state,
+                [ProctoredDeliveryExecution::STATE_AUTHORIZED, ProctoredDeliveryExecution::STATE_ACTIVE]
+            )
+        ) {
             $this->throwUnAuthorizedException($deliveryExecution);
         }
     }

--- a/model/authorization/TestTakerAuthorizationService.php
+++ b/model/authorization/TestTakerAuthorizationService.php
@@ -83,7 +83,8 @@ class TestTakerAuthorizationService extends ConfigurableService implements TestT
                 'Terminated/Finished delivery execution "'.$deliveryExecution->getIdentifier().'" cannot be resumed'
             );
         }
-        $deliveryUri= $deliveryExecution->getDelivery()->getUri();
+        $deliveryUri = $deliveryExecution->getDelivery()->getUri();
+
         if (
             $this->isProctored($deliveryUri, $user)
             && $state !== ProctoredDeliveryExecution::STATE_AUTHORIZED

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -910,8 +910,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->getServiceManager()->register(GuiSettingsService::SERVICE_ID, $guiService);
             $this->setVersion('17.3.0');
         }
-
         $this->skip('17.3.0', '18.2.0');
-
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -910,6 +910,7 @@ class Updater extends common_ext_ExtensionUpdater
             $this->getServiceManager()->register(GuiSettingsService::SERVICE_ID, $guiService);
             $this->setVersion('17.3.0');
         }
-        $this->skip('17.3.0', '18.2.0');
+
+        $this->skip('17.3.0', '18.2.1');
     }
 }

--- a/test/unit/model/authorization/TestTakerAuthorizationServiceTest.php
+++ b/test/unit/model/authorization/TestTakerAuthorizationServiceTest.php
@@ -92,9 +92,7 @@ class TestTakerAuthorizationServiceTest extends TestCase
     {
         return [
             'activeAndUnSecure' => [
-                null,
-                'http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusActive',
-                true
+                null, 'http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusActive', true
             ],
             'activeAndUnSecure2' => [
                 'feature,feature2',
@@ -116,11 +114,7 @@ class TestTakerAuthorizationServiceTest extends TestCase
                 'http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusAuthorized',
                 false
             ],
-            'notActiveAndSecure2' => [
-                'security',
-                'state',
-                false
-            ]
+            'notActiveAndSecure2' => ['security', 'state', false]
         ];
     }
 
@@ -147,7 +141,7 @@ class TestTakerAuthorizationServiceTest extends TestCase
         return [
             ['http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusFinished'],
             ['http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusCanceled'],
-            ['http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusTerminated'],
+            ['http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusTerminated']
         ];
     }
 

--- a/test/unit/model/authorization/TestTakerAuthorizationServiceTest.php
+++ b/test/unit/model/authorization/TestTakerAuthorizationServiceTest.php
@@ -64,25 +64,22 @@ class TestTakerAuthorizationServiceTest extends TestCase
         $property = new core_kernel_classes_Property(
             'http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryTestRunnerFeatures'
         );
-        $this->ontologyMock->expects($this->once())->method('getResource')->with('deliveryUri');
+       $this->ontologyMock->method('getResource')->with('deliveryUri');
 
-        $this->ontologyMock->expects($this->once())
+        $this->ontologyMock
             ->method('getProperty')
             ->with('http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryTestRunnerFeatures')
             ->willReturn($property);
 
-        $delivery->expects($this->once())
+        $delivery
             ->method('getOnePropertyValue')
             ->with($property)
             ->willReturn($propertyValue);
 
         $this->service->setServiceLocator($this->getServiceLocatorMock([Ontology::SERVICE_ID => $this->ontologyMock]));
 
-        if ($expected) {
-            $this->assertTrue($this->service->isActiveUnSecureDelivery('deliveryUri',$state));
-        } else {
-            $this->assertFalse($this->service->isActiveUnSecureDelivery('deliveryUri',$state));
-        }
+        $this->assertEquals($expected, $this->service->isActiveUnSecureDelivery('deliveryUri',$state));
+
     }
 
     /**
@@ -183,15 +180,11 @@ class TestTakerAuthorizationServiceTest extends TestCase
             )
         );
 
-        if ($expected) {
-            $this->assertTrue(
-                $this->service->isProctored('deliveryUri', $this->getMock(User::class))
-            );
-        } else {
-            $this->assertFalse(
-                $this->service->isProctored('deliveryUri', $this->getMock(User::class))
-            );
-        }
+        $this->assertEquals(
+            $expected,
+            $this->service->isProctored('deliveryUri', $this->getMock(User::class))
+        );
+
     }
 
     /**

--- a/test/unit/model/authorization/TestTakerAuthorizationServiceTest.php
+++ b/test/unit/model/authorization/TestTakerAuthorizationServiceTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\taoProctoring\test\unit\model\authorization;
+
+use core_kernel_classes_Property;
+use core_kernel_classes_Resource;
+use Exception;
+use oat\generis\model\data\Ontology;
+use oat\generis\test\TestCase;
+use oat\taoProctoring\model\authorization\TestTakerAuthorizationService;
+
+class TestTakerAuthorizationServiceTest extends TestCase
+{
+
+    /**
+     * @dataProvider isActiveUnSecureDeliveryDataProvider
+     * @param string $propertyValue
+     * @param string $state
+     * @param bool $expected
+     * @throws Exception
+     */
+    public function testIsActiveUnSecureDelivery($propertyValue, $state, $expected)
+    {
+        $ontologyMock = $this->getMock(Ontology::class);
+
+        $delivery = $this
+            ->getMockBuilder(core_kernel_classes_Resource::class)
+            ->setConstructorArgs(['deliveryUri'])
+            ->getMock();
+
+        $property = new core_kernel_classes_Property(
+            'http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryTestRunnerFeatures'
+        );
+
+        $ontologyMock->expects($this->once())
+            ->method('getResource')
+            ->with('deliveryUri')
+            ->willReturn($delivery);
+
+        $ontologyMock->expects($this->once())
+            ->method('getProperty')
+            ->with('http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryTestRunnerFeatures')
+            ->willReturn($property);
+
+        $delivery->expects($this->once())
+            ->method('getOnePropertyValue')
+            ->with($property)
+            ->willReturn($propertyValue);
+
+        $service = (new TestTakerAuthorizationService());
+        $service->setServiceLocator($this->getServiceLocatorMock([Ontology::SERVICE_ID => $ontologyMock]));
+
+        if ($expected) {
+            $this->assertTrue($service->isActiveUnSecureDelivery('deliveryUri',$state));
+        } else {
+            $this->assertFalse($service->isActiveUnSecureDelivery('deliveryUri',$state));
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function isActiveUnSecureDeliveryDataProvider()
+    {
+        return [
+            'activeAndUnSecure' => [
+                null,
+                'http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusActive',
+                true
+            ],
+            'activeAndUnSecure2' => [
+                'feature,feature2',
+                'http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusActive',
+                true
+            ],
+            'notActiveAndUnSecure' => [
+                'feature,feature2',
+                'http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusAuthorized',
+                false
+            ],
+            'ActiveAndSecure' => [
+                'feature,security',
+                'http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusActive',
+                false
+            ],
+            'notActiveAndSecure' => [
+                'feature,security',
+                'http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusAuthorized',
+                false
+            ],
+            'notActiveAndSecure2' => [
+                'security',
+                'state',
+                false
+            ]
+        ];
+    }
+}

--- a/test/unit/model/authorization/TestTakerAuthorizationServiceTest.php
+++ b/test/unit/model/authorization/TestTakerAuthorizationServiceTest.php
@@ -49,8 +49,8 @@ class TestTakerAuthorizationServiceTest extends TestCase
         parent::setUp();
         $this->ontologyMock = $this->getMock(Ontology::class);
         $this->service = new TestTakerAuthorizationService();
-
     }
+
     /**
      * @dataProvider isActiveUnSecureDeliveryDataProvider
      * @param string $propertyValue


### PR DESCRIPTION
Related with: https://oat-sa.atlassian.net/browse/TAO-9572

Steps to reproduce:
1 Create proctored and not secure delivery 
2 Log in as a test taker and run delivery
3 Activate test taker session as proctor
4 Start test as test taker and in any step refresh page
The same steps  for lti run
Expected result: test-taker able to continue test
Actual result: test-taker session become paused and request a proctor activation again
