### PR TITLE
Fix/TAO-9995/Error on proctor bulk action

### DIFF
--- a/controller/Monitor.php
+++ b/controller/Monitor.php
@@ -40,17 +40,16 @@ use oat\taoQtiTest\models\QtiTestExtractionFailedException;
  * @author Open Assessment Technologies SA
  * @package taoProctoring
  * @license GPL-2.0
- *
  */
 class Monitor extends SimplePageModule
 {
     use OntologyAwareTrait;
 
-    const ERROR_AUTHORIZE_EXECUTIONS = 1;
-    const ERROR_PAUSE_EXECUTIONS = 2;
-    const ERROR_TERMINATE_EXECUTIONS = 3;
-    const ERROR_REPORT_IRREGULARITIES = 4;
-    const ERROR_SET_EXTRA_TIME = 5;
+    private const ERROR_AUTHORIZE_EXECUTIONS = 1;
+    private const ERROR_PAUSE_EXECUTIONS = 2;
+    private const ERROR_TERMINATE_EXECUTIONS = 3;
+    private const ERROR_REPORT_IRREGULARITIES = 4;
+    private const ERROR_SET_EXTRA_TIME = 5;
 
     /**
      * Returns the currently proctored delivery
@@ -139,30 +138,30 @@ class Monitor extends SimplePageModule
      * Authorises a delivery execution
      *
      * @throws \common_Exception
-     * @throws \oat\oatbox\service\ServiceNotFoundException
      */
-    public function authoriseExecutions()
+    public function authoriseExecutions(): void
     {
         $deliveryExecution = $this->getRequestParameter('execution');
-        $reason = $this->getRequestParameter('reason');
-        $testCenter = $this->getRequestParameter('testCenter');
 
         if (!is_array($deliveryExecution)) {
-            $deliveryExecution = array($deliveryExecution);
+            $deliveryExecution = [$deliveryExecution];
         }
 
         try {
-
-            $data = DeliveryHelper::authoriseExecutions($deliveryExecution, $reason, $testCenter);
+            $data = DeliveryHelper::authoriseExecutions(
+                $deliveryExecution,
+                $this->getRequestParameter('reason'),
+                $this->getRequestParameter('testCenter')
+            );
 
             $response = [
-                'success' => !count($data['unprocessed']),
-                'data' => $data
+                'success' => !empty($data['processed']),
+                'data' => $data,
             ];
 
-            if (!$response['success']) {
+            if (!empty($data['unprocessed'])) {
                 $response['errorCode'] = self::ERROR_AUTHORIZE_EXECUTIONS;
-                $response['errorMsg'] = __('Some delivery executions have not been authorized');
+                $response['errorMsg'] = __('Some delivery executions have not been authorized.');
             }
 
             $this->returnJson($response);
@@ -176,8 +175,8 @@ class Monitor extends SimplePageModule
 
             $this->returnJson($response);
         } catch (ServiceNotFoundException $e) {
-            \common_Logger::w('No delivery service defined for proctoring');
-            $this->returnError('Proctoring interface not available');
+            \common_Logger::w('No delivery service defined for proctoring.');
+            $this->returnError('Proctoring interface not available.');
         }
     }
 
@@ -186,34 +185,32 @@ class Monitor extends SimplePageModule
      * Terminates delivery executions
      *
      * @throws \common_Exception
-     * @throws \oat\oatbox\service\ServiceNotFoundException
      */
-    public function terminateExecutions()
+    public function terminateExecutions(): void
     {
         $deliveryExecution = $this->getRequestParameter('execution');
-        $reason = $this->getRequestParameter('reason');
 
         if (!is_array($deliveryExecution)) {
-            $deliveryExecution = array($deliveryExecution);
+            $deliveryExecution = [$deliveryExecution];
         }
 
         try {
-            $data = DeliveryHelper::terminateExecutions($deliveryExecution, $reason);
+            $data = DeliveryHelper::terminateExecutions($deliveryExecution, $this->getRequestParameter('reason'));
 
             $response = [
-                'success' => !count($data['unprocessed']),
-                'data' => $data
+                'success' => !empty($data['processed']),
+                'data' => $data,
             ];
 
-            if (!$response['success']) {
+            if (!empty($data['unprocessed'])) {
                 $response['errorCode'] = self::ERROR_TERMINATE_EXECUTIONS;
-                $response['errorMsg'] = __('Some delivery executions have not been terminated');
+                $response['errorMsg'] = __('Some delivery executions have not been terminated.');
             }
 
             $this->returnJson($response);
         } catch (ServiceNotFoundException $e) {
-            \common_Logger::w('No delivery service defined for proctoring');
-            $this->returnError('Proctoring interface not available');
+            \common_Logger::w('No delivery service defined for proctoring.');
+            $this->returnError('Proctoring interface not available.');
         }
     }
 
@@ -221,34 +218,32 @@ class Monitor extends SimplePageModule
      * Pauses delivery executions
      *
      * @throws \common_Exception
-     * @throws \oat\oatbox\service\ServiceNotFoundException
      */
-    public function pauseExecutions()
+    public function pauseExecutions(): void
     {
         $deliveryExecution = $this->getRequestParameter('execution');
-        $reason = $this->getRequestParameter('reason');
 
         if (!is_array($deliveryExecution)) {
-            $deliveryExecution = array($deliveryExecution);
+            $deliveryExecution = [$deliveryExecution];
         }
 
         try {
-            $data = DeliveryHelper::pauseExecutions($deliveryExecution, $reason);
+            $data = DeliveryHelper::pauseExecutions($deliveryExecution, $this->getRequestParameter('reason'));
 
             $response = [
-                'success' => !count($data['unprocessed']),
-                'data' => $data
+                'success' => !empty($data['processed']),
+                'data' => $data,
             ];
 
-            if (!$response['success']) {
+            if (!empty($data['unprocessed'])) {
                 $response['errorCode'] = self::ERROR_PAUSE_EXECUTIONS;
-                $response['errorMsg'] = __('Some delivery executions have not been paused');
+                $response['errorMsg'] = __('Some delivery executions have not been paused.');
             }
 
             $this->returnJson($response);
         } catch (ServiceNotFoundException $e) {
-            \common_Logger::w('No delivery service defined for proctoring');
-            $this->returnError('Proctoring interface not available');
+            \common_Logger::w('No delivery service defined for proctoring.');
+            $this->returnError('Proctoring interface not available.');
         }
     }
 
@@ -256,34 +251,32 @@ class Monitor extends SimplePageModule
      * Report irregularities in delivery executions
      *
      * @throws \common_Exception
-     * @throws \oat\oatbox\service\ServiceNotFoundException
      */
-    public function reportExecutions()
+    public function reportExecutions(): void
     {
         $deliveryExecution = $this->getRequestParameter('execution');
-        $reason = $this->getRequestParameter('reason');
 
         if (!is_array($deliveryExecution)) {
-            $deliveryExecution = array($deliveryExecution);
+            $deliveryExecution = [$deliveryExecution];
         }
 
         try {
-            $data = DeliveryHelper::reportExecutions($deliveryExecution, $reason);
+            $data = DeliveryHelper::reportExecutions($deliveryExecution, $this->getRequestParameter('reason'));
 
             $response = [
-                'success' => !count($data['unprocessed']),
-                'data' => $data
+                'success' => !empty($data['processed']),
+                'data' => $data,
             ];
 
-            if (!$response['success']) {
+            if (!empty($data['unprocessed'])) {
                 $response['errorCode'] = self::ERROR_REPORT_IRREGULARITIES;
-                $response['errorMsg'] = __('Some delivery executions have not been reported');
+                $response['errorMsg'] = __('Some delivery executions have not been reported.');
             }
 
             $this->returnJson($response);
         } catch (ServiceNotFoundException $e) {
-            \common_Logger::w('No delivery service defined for proctoring');
-            $this->returnError('Proctoring interface not available');
+            \common_Logger::w('No delivery service defined for proctoring.');
+            $this->returnError('Proctoring interface not available.');
         }
     }
 
@@ -292,33 +285,35 @@ class Monitor extends SimplePageModule
      *
      * @throws \common_Exception
      */
-    public function extraTime()
+    public function extraTime(): void
     {
         $deliveryExecution = $this->getRequestParameter('execution');
-        $extraTime = floatval($this->getRequestParameter('time'));
 
         if (!is_array($deliveryExecution)) {
-            $deliveryExecution = array($deliveryExecution);
+            $deliveryExecution = [$deliveryExecution];
         }
 
         try {
             $deliveryExecutionManagerService = $this->getServiceLocator()->get(DeliveryExecutionManagerService::SERVICE_ID);
-            $data = $deliveryExecutionManagerService->setExtraTime($deliveryExecution, $extraTime);
+            $data = $deliveryExecutionManagerService->setExtraTime(
+                $deliveryExecution,
+                floatval($this->getRequestParameter('time'))
+            );
 
             $response = [
-                'success' => !count($data['unprocessed']),
-                'data' => $data
+                'success' => !empty($data['processed']),
+                'data' => $data,
             ];
 
-            if (!$response['success']) {
+            if (!empty($data['unprocessed'])) {
                 $response['errorCode'] = self::ERROR_SET_EXTRA_TIME;
-                $response['errorMsg'] = __('Some delivery executions have not been updated');
+                $response['errorMsg'] = __('Some delivery executions have not been updated.');
             }
 
             $this->returnJson($response);
         } catch (ServiceNotFoundException $e) {
-            \common_Logger::w('No delivery service defined for proctoring');
-            $this->returnError('Proctoring interface not available');
+            \common_Logger::w('No delivery service defined for proctoring.');
+            $this->returnError('Proctoring interface not available.');
         }
     }
 }

--- a/manifest.php
+++ b/manifest.php
@@ -48,7 +48,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '18.2.1',
+    'version' => '18.2.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=38.9.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -911,6 +911,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('17.3.0');
         }
 
-        $this->skip('17.3.0', '18.2.1');
+        $this->skip('17.3.0', '18.2.2');
     }
 }


### PR DESCRIPTION
Related to: [https://oat-sa.atlassian.net/browse/TAO-9995](https://oat-sa.atlassian.net/browse/TAO-9995)

There was an error when proctor tried to change multiple records with different statuses.
Changes:
- variables that are used once was replaced by function calls;
- array creation was changed from **array()** to **[]**;
- **count** function on array was replaced with **empty** function, because it works faster (when we need to determine whether the array is empty or not);
- instead of checking number of **unprocessed** users we will check **processed** users to determine right **status**;
- instead of checking **status** to add **error data** we will check number of **unprocessed** users.

Steps to reproduce:
1. have multiple test taker records on the proctor screen, some 'awaiting authorization', others in different statuses;
2. select **ALL** users and try click **Authorize**. You will see list of users that can be authorized and users, that can't;
3. Click **OK**;
You can test it with other statuses and actions. To do that you need to have records with different statuses that cannot be used with each other. For example you can have some **terminated** records and some other. (We cannot terminate records in terminated status, but can terminate in other statuses). 

**Bug**: error "Oops, something went wrong".
**Fix**: success.
 