### PR TITLE
Feature/actp 245/proctor remaining time

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -48,7 +48,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '18.2.5',
+    'version' => '18.2.6',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=38.9.0',

--- a/model/execution/DeliveryExecutionList.php
+++ b/model/execution/DeliveryExecutionList.php
@@ -179,6 +179,7 @@ class DeliveryExecutionList extends ConfigurableService
             $lastActivity = $cachedData[DeliveryMonitoringService::LAST_TEST_TAKER_ACTIVITY];
             $elapsedApprox = $now - $lastActivity;
             $duration = (float) ($cachedData[DeliveryMonitoringService::ITEM_DURATION] ?? 0);
+            $duration -= (float) ($cachedData[DeliveryMonitoringService::STORED_ITEM_DURATION] ?? 0);
             $elapsedApprox += $duration;
         }
 

--- a/model/execution/DeliveryExecutionList.php
+++ b/model/execution/DeliveryExecutionList.php
@@ -176,10 +176,10 @@ class DeliveryExecutionList extends ConfigurableService
             $executionState === DeliveryExecution::STATE_ACTIVE
             && isset($cachedData[DeliveryMonitoringService::LAST_TEST_TAKER_ACTIVITY])
         ) {
-            $lastActivity = $cachedData[DeliveryMonitoringService::LAST_TEST_TAKER_ACTIVITY];
+            $lastActivity = (float)$cachedData[DeliveryMonitoringService::LAST_TEST_TAKER_ACTIVITY];
             $elapsedApprox = $now - $lastActivity;
-            $duration = (float) ($cachedData[DeliveryMonitoringService::ITEM_DURATION] ?? 0);
-            $duration -= (float) ($cachedData[DeliveryMonitoringService::STORED_ITEM_DURATION] ?? 0);
+            $duration = (float)($cachedData[DeliveryMonitoringService::ITEM_DURATION] ?? 0);
+            $duration -= (float)($cachedData[DeliveryMonitoringService::STORED_ITEM_DURATION] ?? 0);
             $elapsedApprox += $duration;
         }
 

--- a/model/monitorCache/DeliveryMonitoringService.php
+++ b/model/monitorCache/DeliveryMonitoringService.php
@@ -63,6 +63,7 @@ interface DeliveryMonitoringService extends DeliveryExecutionDelete
 
     const DIFF_TIMESTAMP = 'diff_timestamp';
     const ITEM_DURATION = 'item_duration';
+    const STORED_ITEM_DURATION = 'stored_item_duration';
 
     const TEST_TAKER_FIRST_NAME = 'test_taker_first_name';
     const TEST_TAKER_LAST_NAME = 'test_taker_last_name';
@@ -81,7 +82,7 @@ interface DeliveryMonitoringService extends DeliveryExecutionDelete
 
     /**
      * Retrieve the currently cached delivery data
-     * 
+     *
      * @param DeliveryExecutionInterface $deliveryExecution
      * @return DeliveryMonitoringData
      */

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -911,6 +911,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('17.3.0');
         }
 
-        $this->skip('17.3.0', '18.2.5');
+        $this->skip('17.3.0', '18.2.6');
     }
 }


### PR DESCRIPTION
Make remaining time on proctor screen more accurate after pause event.
 
Related to : https://oat-sa.atlassian.net/browse/ACTP-245
 
This PR adds an additional value stored in delivery monitoring cache, to track the time that was already stored in timer duration storage.

Steps to reproduce the initial bug and how to test is described in companion PR: https://github.com/oat-sa/extension-tao-act/pull/1295
 

#### Dependencies
 
Companion :
 - [ ] https://github.com/oat-sa/extension-tao-act/pull/1295
   