### PR TITLE
Feature/actp 282/decide if delivery is secure based on plugin

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -48,7 +48,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '18.3.2',
+    'version' => '19.0.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=38.9.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -911,6 +911,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('17.3.0');
         }
 
-        $this->skip('17.3.0', '18.3.2');
+        $this->skip('17.3.0', '19.0.0');
     }
 }


### PR DESCRIPTION
Should be merged after https://github.com/oat-sa/extension-lti-proctoring/pull/128

JIRA: https://oat-sa.atlassian.net/browse/ACTP-282

The goal of this PR is to change logic how do we check if delivery execution is in secure mode. Only `blurPause` plugin should be used to check if delivery execution should be paused when focus is lost in test runner. This plugin may be included in multiple features. 
With the new implementation we will get list of enabled plugins from DeliveryContainerService (which will handle LTI parameters for available test runner features as well) and decide if test taker is authorized to resume the test.