### PR TITLE
Fix/actp 383/avoid empty irregularity dialog

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -48,7 +48,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.2.0',
+    'version' => '19.2.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=38.9.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -911,6 +911,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('17.3.0');
         }
 
-        $this->skip('17.3.0', '19.2.0');
+        $this->skip('17.3.0', '19.2.1');
     }
 }

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -1100,10 +1100,10 @@ define([
                             dataset = newDataset;
 
                             // activate irregularity buttons
-                            $('.terminateOrReactivateAndIrregularity', $list).each(function (ind, btn) {
-                                var $btn = $(btn);
-                                var uri = $btn.closest('[data-item-identifier]').data('item-identifier');
-                                var delivery = getExecutionData(uri);
+                            $('.terminateOrReactivateAndIrregularity', $list).each((ind, btn) => {
+                                const $btn = $(btn);
+                                const uri = $btn.closest('[data-item-identifier]').data('item-identifier');
+                                const delivery = getExecutionData(uri);
                                 if (
                                   hasAccessToReactivate && canDo('reactivate', delivery.state)
                                       || canDo('terminate', delivery.state)

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -352,12 +352,14 @@ define([
                         });
                     }
 
-                    dialog({
-                        message: __('Please, make your selection'),
-                        autoRender: true,
-                        autoDestroy: true,
-                        buttons: buttons
-                    });
+                    if (buttons.length) {
+                        dialog({
+                            message: __('Please, make your selection'),
+                            autoRender: true,
+                            autoDestroy: true,
+                            buttons: buttons
+                        });
+                    }
                 }
 
                 // display the session history
@@ -1056,9 +1058,9 @@ define([
                         id: 'terminateOrReactivateAndIrregularity',
                         icon: 'delivery-small',
                         title: label,
+                        disabled: true,
                         action: terminateOrReactivateAndIrregularity
                     }];
-
 
                     if (showActionShowHistory) {
                         actionList.push({
@@ -1096,6 +1098,20 @@ define([
 
                             //update dateset in memory
                             dataset = newDataset;
+
+                            // activate irregularity buttons
+                            $('.terminateOrReactivateAndIrregularity', $list).each(function (ind, btn) {
+                                var $btn = $(btn);
+                                var uri = $btn.closest('[data-item-identifier]').data('item-identifier');
+                                var delivery = getExecutionData(uri);
+                                if (
+                                  hasAccessToReactivate && canDo('reactivate', delivery.state)
+                                      || canDo('terminate', delivery.state)
+                                      || allowIrr
+                                ) {
+                                    $btn.prop('disabled', false);
+                                }
+                            });
 
                             //update the buttons, which have been reconstructed
                             actionButtons = _({


### PR DESCRIPTION
Pull request summary
 
Related to : https://oat-sa.atlassian.net/browse/ACTP-383
 
When the new allow_irr parameter is false, a buttonless pop up box comes up when a test was completed or terminated. 
 
#### Steps to reproduce  (for bugs)
 - run lti proctoring with optional parameter `allow_irr=false`
 - click on the `terminate/reactivate or irregularity button` of the delivery that was terminated or finished
 - there is no buttons in the dialog

#### How to test
 - run lti proctoring with optional parameter `allow_irr=false`
 - button `terminate/reactivate or irregularity button` should be disabled for the delivery executions that was finished or terminated
