### PR TITLE
Fix/actp 415/card announcement proctoring page

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -48,7 +48,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.3.2',
+    'version' => '19.3.3',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=41.9.1',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -911,6 +911,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('17.3.0');
         }
 
-        $this->skip('17.3.0', '19.3.2');
+        $this->skip('17.3.0', '19.3.3');
     }
 }

--- a/views/js/templates/deliveryServer/authorizationEntryPoint.tpl
+++ b/views/js/templates/deliveryServer/authorizationEntryPoint.tpl
@@ -1,5 +1,5 @@
 <div class="entry-point-box authorization-container">
-    <div class="block entry-point entry-point-all-deliveries" tabindex="0">
+    <div class="block entry-point entry-point-all-deliveries">
         <h1>{{label}}</h1>
         <p class="authorization-status" aria-label="{{__ "Authorization status"}}">{{__ 'Please wait, authorization in process ...'}}</p>
         <div class="authorization-actions clearfix"></div>


### PR DESCRIPTION
**Related to:**
https://oat-sa.atlassian.net/browse/ACTP-415

**Description:**
The card on Proctoring page has it's own tab stop. This does not make sense.

**How to check:**
Login as test taker and start some test with proctoring enabled.
The card on Proctoring page: `<div class="block entry-point …">` should not have `tabindex="0"`.
