### PR TITLE
Predefined title for the authorization page

### DIFF
--- a/controller/DeliveryServer.php
+++ b/controller/DeliveryServer.php
@@ -99,6 +99,7 @@ class DeliveryServer extends DefaultDeliveryServer
             $this->setData('client_config_url', $this->getClientConfigUrl());
             $this->setData('showControls', true);
             $this->setData('runDeliveryUrl', $runDeliveryUrl);
+            $this->setData('title', __("TAO - An Open and Versatile Computer-Based Assessment Platform"));
 
             //set template
             $this->setData('homeUrl', $this->getServiceManager()->get(DefaultUrlService::SERVICE_ID)->getUrl('ProctoringHome'));


### PR DESCRIPTION
Pull request summary
 
Related to : https://oat-sa.atlassian.net/browse/TCA-341
 
With changes from https://github.com/oat-sa/extension-tao-delivery/pull/462 will be used default title instead of expected.
  
#### How to test
 
Delivery authorization page has correct title (even with PR https://github.com/oat-sa/extension-tao-delivery/pull/462).
  
#### Dependencies
 
Companion PR :
 - [ ] https://github.com/oat-sa/tao-core/pull/2488
 - [ ] https://github.com/oat-sa/extension-tao-delivery/pull/462