### PR TITLE
default title of the authorization page

### DIFF
--- a/controller/DeliveryServer.php
+++ b/controller/DeliveryServer.php
@@ -105,6 +105,7 @@ class DeliveryServer extends DefaultDeliveryServer
             $this->setData('logout', $this->getServiceManager()->get(DefaultUrlService::SERVICE_ID)->getUrl('ProctoringLogout'));
             $this->setData('content-template', 'DeliveryServer/awaiting.tpl');
             $this->setData('content-extension', 'taoProctoring');
+            $this->setData('title', __('TAO: User Authorization'));
             $this->setView('DeliveryServer/layout.tpl', 'taoDelivery');
         } else {
             // inconsistent state

--- a/manifest.php
+++ b/manifest.php
@@ -48,11 +48,11 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.6.0',
+    'version' => '19.7.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=41.9.1',
-        'taoDelivery'    => '>=13.1.2',
+        'taoDelivery'    => '>=14.14.0',
         'taoDeliveryRdf' => '>=7.0.0',
         'taoTestTaker'   => '>=4.0.0',
         'taoQtiTest'     => '>=37.6.1',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -936,6 +936,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('19.5.0');
         }
 
-        $this->skip('19.5.0', '19.6.0');
+        $this->skip('19.5.0', '19.7.0');
     }
 }


### PR DESCRIPTION
Pull request summary
 
Related to : https://oat-sa.atlassian.net/browse/TCA-341
 
Default title for authorization page
 
#### How to test
 
Check pages:
	• delivery authoring: TAO: User Authorization

#### Dependencies

Requires:
 - [ ] https://github.com/oat-sa/extension-tao-delivery/pull/463