### PR TITLE
Fix/tca 414/a11y layout

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -48,7 +48,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.10.0',
+    'version' => '19.10.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=41.9.1',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -949,5 +949,7 @@ class Updater extends common_ext_ExtensionUpdater
             $this->getServiceManager()->register(EventManager::SERVICE_ID, $eventManager);
             $this->setVersion('19.10.0');
         }
+
+        $this->skip('19.10.0', '19.10.1');
     }
 }

--- a/views/templates/DeliveryServer/awaiting.tpl
+++ b/views/templates/DeliveryServer/awaiting.tpl
@@ -2,7 +2,7 @@
 use oat\tao\helpers\Template;
 use oat\tao\helpers\Layout;
 ?>
-<div class="section-container">
+<div class="section-container" role="main" aria-label="<?= __('Proctor authorization') ?>">
     <div class="clear content-wrapper content-panel">
         <section class="content-container awaiting-authorization authorization-in-progress">
         </section>


### PR DESCRIPTION
**Related**
https://oat-sa.atlassian.net/browse/TCA-414

**Description**
A11y issues on the Proctoring page

**How to test:**

1. Create delivery with the proctoring screen
2. Reach the proctoring screen as a test tacker
3. Ensure that `<div class="section-container">` has the `role="main"` and `aria-label="Proctor authorization”`
4. Ensure that it is correctly announced by the screen reader