### PR TITLE
Fix TBD-33: impossible to resume a timed out delivery execution

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -18,25 +18,31 @@
  *
  *
  */
+
 use oat\tao\model\user\TaoRoles;
 use oat\taoProctoring\controller\DeliverySelection;
 use oat\taoProctoring\controller\Monitor;
 use oat\taoProctoring\controller\MonitorProctorAdministrator;
 use oat\taoProctoring\controller\Tools;
 use oat\taoProctoring\model\ProctorService;
+use oat\taoProctoring\scripts\install\OverrideSectionPauseService;
 use oat\taoProctoring\scripts\install\RegisterAuthProvider;
 use oat\taoProctoring\scripts\install\RegisterBreadcrumbsServices;
+use oat\taoProctoring\scripts\install\RegisterDeleteDeliveryExecution;
 use oat\taoProctoring\scripts\install\RegisterDeliveryExecutionManagerService;
 use oat\taoProctoring\scripts\install\RegisterDeliveryServerService;
 use oat\taoProctoring\scripts\install\RegisterGuiSettingsService;
+use oat\taoProctoring\scripts\install\RegisterProctorAttemptService;
 use oat\taoProctoring\scripts\install\RegisterProctoringDeliveryDeleteService;
 use oat\taoProctoring\scripts\install\RegisterProctoringEntryPoint;
 use oat\taoProctoring\scripts\install\RegisterProctoringLog;
+use oat\taoProctoring\scripts\install\RegisterProctoringRunnerService;
 use oat\taoProctoring\scripts\install\RegisterReasonCategoryService;
 use oat\taoProctoring\scripts\install\RegisterRunnerMessageService;
 use oat\taoProctoring\scripts\install\RegisterServices;
 use oat\taoProctoring\scripts\install\RegisterWebhookEvents;
 use oat\taoProctoring\scripts\install\SetupDeliveryMonitoring;
+use oat\taoProctoring\scripts\install\SetupProctorCsvImporter;
 use oat\taoProctoring\scripts\install\SetupProctoringEventListeners;
 use oat\taoProctoring\scripts\install\SetUpProctoringUrlService;
 use oat\taoProctoring\scripts\install\SetUpQueueTasks;
@@ -48,7 +54,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.10.2',
+    'version' => '19.10.3',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=41.9.1',
@@ -65,7 +71,7 @@ return array(
         array('grant', 'http://www.tao.lu/Ontologies/TAO.rdf#GlobalManagerRole', array('ext' => 'taoProctoring', 'mod'=>'Irregularity')),
         array('grant', ProctorService::ROLE_PROCTOR, DeliverySelection::class),
         array('grant', ProctorService::ROLE_PROCTOR, Monitor::class),
-        array('grant', ProctorService::ROLE_PROCTOR, \tao_actions_Breadcrumbs::class),
+        array('grant', ProctorService::ROLE_PROCTOR, tao_actions_Breadcrumbs::class),
         array('grant', ProctorService::ROLE_PROCTOR, array('ext'=>'taoProctoring', 'mod'=>'Reporting')),
         array('grant', ProctorService::ROLE_PROCTOR, array('ext'=>'taoProctoring', 'mod'=>'TextConverter')),
         array('grant', TaoRoles::DELIVERY, array('ext'=>'taoProctoring', 'mod'=>'DeliveryServer')),
@@ -88,13 +94,13 @@ return array(
             RegisterRunnerMessageService::class,
             RegisterGuiSettingsService::class,
             RegisterDeliveryExecutionManagerService::class,
-            \oat\taoProctoring\scripts\install\OverrideSectionPauseService::class,
-            \oat\taoProctoring\scripts\install\RegisterProctoringRunnerService::class,
-            \oat\taoProctoring\scripts\install\SetupProctorCsvImporter::class,
-            \oat\taoProctoring\scripts\install\RegisterProctorAttemptService::class,
+            OverrideSectionPauseService::class,
+            RegisterProctoringRunnerService::class,
+            SetupProctorCsvImporter::class,
+            RegisterProctorAttemptService::class,
             RegisterProctoringDeliveryDeleteService::class,
             SetUpQueueTasks::class,
-            \oat\taoProctoring\scripts\install\RegisterDeleteDeliveryExecution::class,
+            RegisterDeleteDeliveryExecution::class,
             RegisterWebhookEvents::class
         ),
         'rdf' => array(
@@ -113,12 +119,12 @@ return array(
     'update' => 'oat\\taoProctoring\\scripts\\update\\Updater',
 	'constants' => array(
 	    # views directory
-	    "DIR_VIEWS" => dirname(__FILE__).DIRECTORY_SEPARATOR."views".DIRECTORY_SEPARATOR,
+	    'DIR_VIEWS' => __DIR__ . DIRECTORY_SEPARATOR . 'views' . DIRECTORY_SEPARATOR,
 
 		#BASE URL (usually the domain root)
 		'BASE_URL' => ROOT_URL.'taoProctoring/',
 	),
     'extra' => array(
-        'structures' => dirname(__FILE__) . DIRECTORY_SEPARATOR . 'controller' . DIRECTORY_SEPARATOR . 'structures.xml',
+        'structures' => __DIR__ . DIRECTORY_SEPARATOR . 'controller' . DIRECTORY_SEPARATOR . 'structures.xml',
     )
 );

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -37,6 +37,10 @@ use oat\tao\model\user\TaoRoles;
 use oat\tao\model\webhooks\WebhookEventsServiceInterface;
 use oat\tao\scripts\update\OntologyUpdater;
 use oat\taoDelivery\model\AssignmentService;
+use oat\taoDelivery\model\AttemptService;
+use oat\taoDelivery\model\AttemptServiceInterface;
+use oat\taoDelivery\model\execution\Counter\DeliveryExecutionCounterInterface;
+use oat\taoDelivery\model\execution\Delete\DeliveryExecutionDeleteService;
 use oat\taoDelivery\model\execution\StateServiceInterface;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionCreated;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState;
@@ -44,12 +48,14 @@ use oat\taoDeliveryRdf\model\Delete\DeliveryDeleteService;
 use oat\taoDeliveryRdf\model\event\DeliveryCreatedEvent;
 use oat\taoDeliveryRdf\model\event\DeliveryUpdatedEvent;
 use oat\taoDeliveryRdf\model\GroupAssignment;
+use oat\taoEventLog\model\eventLog\LoggerService;
 use oat\taoProctoring\controller\DeliverySelection;
 use oat\taoProctoring\controller\ExecutionRestService;
 use oat\taoProctoring\controller\Monitor;
 use oat\taoProctoring\controller\MonitorProctorAdministrator;
 use oat\taoProctoring\controller\Tools;
 use oat\taoProctoring\model\ActivityMonitoringService;
+use oat\taoProctoring\model\AssessmentResultsService;
 use oat\taoProctoring\model\authorization\AuthorizationGranted;
 use oat\taoProctoring\model\authorization\TestTakerAuthorizationDelegator;
 use oat\taoProctoring\model\authorization\TestTakerAuthorizationInterface;
@@ -60,14 +66,16 @@ use oat\taoProctoring\model\deliveryLog\implementation\RdsDeliveryLogService;
 use oat\taoProctoring\model\deliveryLog\listener\DeliveryLogTimerAdjustedEventListener;
 use oat\taoProctoring\model\event\DeliveryExecutionFinished;
 use oat\taoProctoring\model\event\DeliveryExecutionTimerAdjusted;
+use oat\taoProctoring\model\execution\Counter\DeliveryExecutionCounterService;
+use oat\taoProctoring\model\execution\DeliveryExecution as ProctoredDeliveryExecution;
 use oat\taoProctoring\model\execution\DeliveryExecutionManagerService;
 use oat\taoProctoring\model\execution\ProctoredSectionPauseService;
-use oat\taoProctoring\model\FinishDeliveryExecutionsService;
-use oat\taoProctoring\model\TerminateDeliveryExecutionsService;
 use oat\taoProctoring\model\execution\ProctoringDeliveryDeleteService;
+use oat\taoProctoring\model\FinishDeliveryExecutionsService;
 use oat\taoProctoring\model\GuiSettingsService;
 use oat\taoProctoring\model\implementation\DeliveryExecutionStateService;
 use oat\taoProctoring\model\implementation\TestRunnerMessageService;
+use oat\taoProctoring\model\import\ProctorCsvImporter;
 use oat\taoProctoring\model\monitorCache\DeliveryMonitoringService;
 use oat\taoProctoring\model\monitorCache\implementation\MonitoringStorage;
 use oat\taoProctoring\model\monitorCache\update\TestUpdate;
@@ -79,23 +87,15 @@ use oat\taoProctoring\model\runner\ProctoringRunnerService;
 use oat\taoProctoring\model\service\AbstractIrregularityReport;
 use oat\taoProctoring\model\service\IrregularityReport;
 use oat\taoProctoring\model\ServiceDelegatorInterface;
+use oat\taoProctoring\model\TerminateDeliveryExecutionsService;
 use oat\taoProctoring\scripts\install\RegisterBreadcrumbsServices;
 use oat\taoProctoring\scripts\install\RegisterGuiSettingsService;
 use oat\taoProctoring\scripts\install\RegisterRunnerMessageService;
 use oat\taoProctoring\scripts\install\SetUpProctoringUrlService;
-use oat\taoQtiTest\models\SectionPauseService;
 use oat\taoQtiTest\models\event\QtiTestStateChangeEvent;
-use oat\taoProctoring\model\import\ProctorCsvImporter;
+use oat\taoQtiTest\models\SectionPauseService;
 use oat\taoTests\models\event\TestChangedEvent;
 use oat\taoTests\models\event\TestExecutionPausedEvent;
-use oat\taoEventLog\model\eventLog\LoggerService;
-use oat\taoDelivery\model\AttemptService;
-use oat\taoDelivery\model\AttemptServiceInterface;
-use oat\taoProctoring\model\execution\DeliveryExecution as ProctoredDeliveryExecution;
-use oat\taoProctoring\model\AssessmentResultsService;
-use oat\taoProctoring\model\execution\Counter\DeliveryExecutionCounterService;
-use oat\taoDelivery\model\execution\Counter\DeliveryExecutionCounterInterface;
-use oat\taoDelivery\model\execution\Delete\DeliveryExecutionDeleteService;
 
 /**
  *
@@ -200,7 +200,7 @@ class Updater extends common_ext_ExtensionUpdater
                 [TaoRoles::ANONYMOUS, 'oat\\taoProctoring\\controller\\DiagnosticChecker']
             );
             foreach ($old as $row) {
-                list($role, $acl) = $row;
+                [$role, $acl] = $row;
                 AclProxy::revokeRule(new AccessRule('grant', $role, $acl));
             }
             $this->setVersion('4.0.0');
@@ -950,6 +950,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('19.10.0');
         }
 
-        $this->skip('19.10.0', '19.10.2');
+        $this->skip('19.10.0', '19.10.3');
     }
 }


### PR DESCRIPTION
- [TBD-33](https://oat-sa.atlassian.net/browse/TBD-33) fix: apply custom delivery execution session manipulations after setting a delivery execution state so that they're applied last
- [TBD-33](https://oat-sa.atlassian.net/browse/TBD-33) chore(version): bump a fix one