### PR TITLE
Fix/tca 647/remaining time mismatch

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.13.1',
+    'version' => '19.14.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=41.9.1',

--- a/scripts/install/db/DbSetup.php
+++ b/scripts/install/db/DbSetup.php
@@ -25,14 +25,14 @@ use oat\taoProctoring\model\monitorCache\implementation\MonitoringStorage;
 use common_Logger;
 
 class DbSetup {
-    
+
     public static function generateTable(\common_persistence_SqlPersistence $persistence)
     {
 
         $schemaManager = $persistence->getDriver()->getSchemaManager();
         $schema = $schemaManager->createSchema();
         $fromSchema = clone $schema;
-        
+
         try {
             $tableLog = $schema->createTable(MonitoringStorage::TABLE_NAME);
             $tableLog->addOption('engine', 'InnoDB');
@@ -52,9 +52,11 @@ class DbSetup {
             $tableLog->addColumn(MonitoringStorage::EXTENDED_TIME, "string", array("notnull" => false, "length" => 255));
             $tableLog->addColumn(MonitoringStorage::EXTRA_TIME, "string", array("notnull" => false, "length" => 255));
             $tableLog->addColumn(MonitoringStorage::CONSUMED_EXTRA_TIME, "string", array("notnull" => false, "length" => 255));
+            $tableLog->addColumn(MonitoringStorage::ITEM_DURATION, "string", array("notnull" => false, "length" => 32));
+            $tableLog->addColumn(MonitoringStorage::STORED_ITEM_DURATION, "string", array("notnull" => false, "length" => 32));
 
             $tableLog->setPrimaryKey(array(MonitoringStorage::COLUMN_DELIVERY_EXECUTION_ID));
-        
+
             $tableLog->addIndex(
                 array(MonitoringStorage::COLUMN_DELIVERY_EXECUTION_ID),
                 'IDX_' . MonitoringStorage::COLUMN_DELIVERY_EXECUTION_ID . '_' . MonitoringStorage::COLUMN_DELIVERY_EXECUTION_ID
@@ -71,15 +73,15 @@ class DbSetup {
                 array(MonitoringStorage::COLUMN_DELIVERY_EXECUTION_ID),
                 'IDX_' . MonitoringStorage::TABLE_NAME . '_' . MonitoringStorage::COLUMN_DELIVERY_EXECUTION_ID . '_UNIQUE'
             );
-        
+
             $tableData = $schema->createTable(MonitoringStorage::KV_TABLE_NAME);
             $tableData->addOption('engine', 'InnoDB');
             $tableData->addColumn(MonitoringStorage::KV_COLUMN_PARENT_ID, "string", array("notnull" => true, "length" => 255));
             $tableData->addColumn(MonitoringStorage::KV_COLUMN_KEY, "string", array("notnull" => true, "length" => 255));
             $tableData->addColumn(MonitoringStorage::KV_COLUMN_VALUE, "text", array("notnull" => false));
-        
+
             $tableData->setPrimaryKey(array(MonitoringStorage::KV_COLUMN_PARENT_ID, MonitoringStorage::KV_COLUMN_KEY));
-        
+
             $tableData->addForeignKeyConstraint(
                 $tableLog,
                 array(MonitoringStorage::KV_COLUMN_PARENT_ID),
@@ -93,7 +95,7 @@ class DbSetup {
         } catch(SchemaException $e) {
             common_Logger::i('Database Schema already up to date.');
         }
-        
+
         $queries = $persistence->getPlatform()->getMigrateSchemaSql($fromSchema, $schema);
         foreach ($queries as $query) {
             $persistence->exec($query);
@@ -124,6 +126,8 @@ class DbSetup {
             MonitoringStorage::EXTENDED_TIME,
             MonitoringStorage::EXTRA_TIME,
             MonitoringStorage::CONSUMED_EXTRA_TIME,
+            MonitoringStorage::ITEM_DURATION,
+            MonitoringStorage::STORED_ITEM_DURATION,
         ];
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -951,5 +951,12 @@ class Updater extends common_ext_ExtensionUpdater
         }
 
         $this->skip('19.10.0', '19.13.1');
+
+        if ($this->isVersion('19.13.1')) {
+            $script = 'sudo -u www-data php index.php \'oat\taoProctoring\scripts\tools\KvMonitoringMigration\' -f item_duration,stored_item_duration -d 1 -s 0 -pc -l 32';
+            $this->addReport(\common_report_Report::createInfo("Run script :'" . $script . "' to finish updating. Time to completion depends on table size."));
+
+            $this->setVersion('19.14.0');
+        }
     }
 }


### PR DESCRIPTION
Moving several columns from `kv_delivery_monitoring` to `delivery_monitoring` table.
 
Related to : https://oat-sa.atlassian.net/browse/TCA-647
  
#### How to test

No changes in the UI or in behavior in tao community edition.