### PR TITLE
Feature/NCC-222/implement data polling for proctoring page

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.14.0',
+    'version' => '19.15.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=41.9.1',

--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.15.0',
+    'version' => '19.16.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=41.9.1',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -950,6 +950,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('19.10.0');
         }
 
-        $this->skip('19.10.0', '19.14.0');
+        $this->skip('19.10.0', '19.15.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -958,5 +958,7 @@ class Updater extends common_ext_ExtensionUpdater
 
             $this->setVersion('19.15.0');
         }
+
+        $this->setVersion('19.15.0', '19.16.0');
     }
 }

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -819,7 +819,7 @@ define([
                                 title: __('Refresh the page'),
                                 label: __('Refresh'),
                                 action() {
-                                    $list.datatable('refresh', {});
+                                    $list.datatable('refresh');
                                 }
                             });
                         }

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -742,14 +742,8 @@ define([
                         return _.isEqual(response, savedResponse);
                     }
 
-                    function startPollingData(data, ajaxConfig) {
-                        const isPollingAvailable = data.autoRefresh && ajaxConfig;
-
+                    function startPollingData(pollingInterval, ajaxConfig) {
                         stopPollingData();
-
-                        if (!isPollingAvailable) {
-                            return;
-                        }
 
                         dataPolling.setAction(function (process) {
                             const action = process.async();
@@ -769,7 +763,7 @@ define([
                                 .fail(action.resolve);
                         });
 
-                        dataPolling.setInterval(data.autoRefresh);
+                        dataPolling.setInterval(pollingInterval);
                         dataPolling.start();
                     }
 
@@ -1304,7 +1298,12 @@ define([
                             .on('query.datatable', function (event, ajaxConfig) {
                                 loadingBar.start();
                                 highlightRows = [];
-                                startPollingData(data, ajaxConfig);
+
+                                const isPollingAvailable = data.autoRefresh && ajaxConfig;
+
+                                if (isPollingAvailable) {
+                                    startPollingData(data.autoRefresh, ajaxConfig);
+                                }
                             })
                             .on('beforeload.datatable', (e, dataSet) => {
                                 // We save response data here because on load the data will be transformed
@@ -1356,6 +1355,7 @@ define([
                                     polling.stop();
                                 });
 
+                                console.log('Start timer');
                                 polling.start();
                                 timer.resume();
                             })

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -721,17 +721,17 @@ define([
                                     return true;
                                 }
 
-                                // We have to exlude the timer property from comparising since
-                                // the values for that property are always changed when test is in progress state
-                                const omitPropertiesToBeCompare = ['timer'];
-
                                 while (newDataSize--) {
-                                    let isDataEqual = _.isEqual(
-                                        _.omit(newData[newDataSize], omitPropertiesToBeCompare),
-                                        _.omit(savedData[newDataSize], omitPropertiesToBeCompare)
-                                    );
+                                    const newDeliveryId = newData[newDataSize].id;
+                                    const newDeliveryStatus = newData[newDataSize].state.status;
+                                    const savedDeliveryId = savedData[newDataSize].id;
+                                    const savedDeliveryStatus = savedData[newDataSize].state.status;
 
-                                    if (!isDataEqual) {
+                                    const isDeliveriesEqual =
+                                        _.isEqual(newDeliveryId, savedDeliveryId) &&
+                                        _.isEqual(newDeliveryStatus, savedDeliveryStatus);
+
+                                    if (!isDeliveriesEqual) {
                                         return true;
                                     }
                                 }

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -96,7 +96,6 @@ define([
     var historyUrl = urlHelper.route('index', 'Reporting', 'taoProctoring');
     const adjustTimeUrl = urlHelper.route('adjustTime', 'Monitor', 'taoProctoring');
 
-
     /**
      * The extra time unit: by default in minutes
      * @type {Number}
@@ -109,10 +108,12 @@ define([
      * @returns {boolean}
      */
     function validateParams(params) {
-        return _.isPlainObject(params) &&
+        return (
+            _.isPlainObject(params) &&
             (_.isUndefined(params.delivery) || !_.isEmpty(params.delivery)) &&
             (_.isUndefined(params.testCenter) || !_.isEmpty(params.testCenter)) &&
-            !_.isEmpty(params.execution);
+            !_.isEmpty(params.execution)
+        );
     }
 
     // the page is always loading data when starting
@@ -138,6 +139,7 @@ define([
             var allowIrr = pageParams.allowIrr !== 'false';
             var defaultAvailableLabel = __('Current sessions');
             var dataset;
+            var originalDataset;
             var extraFields;
             var categories;
             let timeHandlingMode;
@@ -176,260 +178,282 @@ define([
                 interval: 1000,
                 autoStart: false
             });
-            appController.on('change.deliveryMonitoring', function() {
+
+            const dataPolling = pollingFactory({
+                interval: 2000,
+                autoStart: false
+            });
+
+            appController.on('change.deliveryMonitoring', function () {
                 appController.off('.deliveryMonitoring');
                 container.destroy();
             });
 
-            proxyFactory('ajax').init({
-                actions: {
-                    read: serviceUrl,
-                    authorize: {
-                        url: authorizeUrl,
-                        validate: validateParams
-                    },
-                    pause: {
-                        url: pauseUrl,
-                        validate: validateParams
-                    },
-                    terminate: {
-                        url: terminateUrl,
-                        validate: validateParams
-                    },
-                    reactivate: {
-                        url: reactivateUrl,
-                        validate: validateParams
-                    },
-                    report: {
-                        url: reportUrl,
-                        validate: validateParams
-                    },
-                    extraTime: {
-                        url: extraTimeUrl,
-                        validate: validateParams
-                    },
-                    adjustTime: {
-                        url: adjustTimeUrl,
-                        validate: validateParams
+            proxyFactory('ajax')
+                .init({
+                    actions: {
+                        read: serviceUrl,
+                        authorize: {
+                            url: authorizeUrl,
+                            validate: validateParams
+                        },
+                        pause: {
+                            url: pauseUrl,
+                            validate: validateParams
+                        },
+                        terminate: {
+                            url: terminateUrl,
+                            validate: validateParams
+                        },
+                        reactivate: {
+                            url: reactivateUrl,
+                            validate: validateParams
+                        },
+                        report: {
+                            url: reportUrl,
+                            validate: validateParams
+                        },
+                        extraTime: {
+                            url: extraTimeUrl,
+                            validate: validateParams
+                        },
+                        adjustTime: {
+                            url: adjustTimeUrl,
+                            validate: validateParams
+                        }
                     }
-                }
-            }).then(function(proxyExecutions) {
-                // request the server with a selection of test takers
-                function request(action, selection, data, message) {
-                    var params;
-                    if (selection && selection.length) {
-                        loadingBar.start();
+                })
+                .then(function (proxyExecutions) {
+                    // request the server with a selection of test takers
+                    function request(action, selection, data, message) {
+                        var params;
+                        if (selection && selection.length) {
+                            loadingBar.start();
 
-                        params = _.merge({
-                            execution: selection
-                        }, data);
+                            params = _.merge(
+                                {
+                                    execution: selection
+                                },
+                                data
+                            );
 
-                        if (deliveryId) {
-                            params.delivery = deliveryId;
-                        }
+                            if (deliveryId) {
+                                params.delivery = deliveryId;
+                            }
 
-                        if (context) {
-                            params.testCenter = context;
-                        }
+                            if (context) {
+                                params.testCenter = context;
+                            }
 
-                        proxyExecutions.action(action, params)
-                            .then(function() {
-                                if (message) {
-                                    feedback().success(message);
-                                }
-                                $list.datatable('refresh');
-                            })
-                            .catch(function(err) {
-                                var messageContext = '',
-                                    responseData,
-                                    unprocessed;
+                            proxyExecutions
+                                .action(action, params)
+                                .then(function () {
+                                    if (message) {
+                                        feedback().success(message);
+                                    }
+                                    $list.datatable('refresh');
+                                })
+                                .catch(function (err) {
+                                    var messageContext = '',
+                                        responseData,
+                                        unprocessed;
 
-                                if (err.response) {
-                                    responseData = err.response.data;
-                                    unprocessed = _.map(responseData.unprocessed, function (msg, id) {
-                                        var execution;
+                                    if (err.response) {
+                                        responseData = err.response.data;
+                                        unprocessed = _.map(responseData.unprocessed, function (msg, id) {
+                                            var execution;
 
-                                        if (!id) {
-                                            id = msg;
-                                            msg = null;
-                                        }
-
-                                        if (msg) {
-                                            return msg;
-                                        } else {
-                                            execution = getExecutionData(id);
-
-                                            if (execution) {
-                                                return __('Session %s - %s has not been processed', execution.delivery.label, execution.start_time);
+                                            if (!id) {
+                                                id = msg;
+                                                msg = null;
                                             }
-                                        }
-                                    });
 
-                                    if (unprocessed.length) {
-                                        messageContext += `<br>${unprocessed.join('<br>')}`;
+                                            if (msg) {
+                                                return msg;
+                                            } else {
+                                                execution = getExecutionData(id);
+
+                                                if (execution) {
+                                                    return __(
+                                                        'Session %s - %s has not been processed',
+                                                        execution.delivery.label,
+                                                        execution.start_time
+                                                    );
+                                                }
+                                            }
+                                        });
+
+                                        if (unprocessed.length) {
+                                            messageContext += `<br>${unprocessed.join('<br>')}`;
+                                        }
+                                        if (responseData.error) {
+                                            messageContext += `<br>${encode.html(responseData.error)}`;
+                                        }
                                     }
-                                    if (responseData.error) {
-                                        messageContext += `<br>${encode.html(responseData.error)}`;
-                                    }
+                                    appController.onError(err);
+                                    feedback().error(`${__('Something went wrong ...')}<br>${messageContext}`, {
+                                        encodeHtml: false
+                                    });
+                                })
+                                .then(function () {
+                                    loadingBar.stop();
+                                });
+                        }
+                    }
+
+                    // request the server to authorize the selected delivery executions
+                    function authorize(selection) {
+                        execBulkAction('authorize', __('Authorize Session'), selection, function (sel, reason) {
+                            request('authorize', sel, { reason: reason }, __('Sessions authorized'));
+                        });
+                    }
+
+                    // request the server to pause the selected delivery executions
+                    function pause(selection) {
+                        execBulkAction('pause', __('Pause Session'), selection, function (sel, reason) {
+                            request('pause', sel, { reason: reason }, __('Sessions paused'));
+                        });
+                    }
+
+                    // request the server to terminate the selected delivery executions
+                    function terminate(selection) {
+                        execBulkAction('terminate', __('Terminate Session'), selection, function (sel, reason) {
+                            request('terminate', sel, { reason: reason }, __('Sessions terminated'));
+                        });
+                    }
+
+                    // request the reactivate to reactivate the selected delivery executions
+                    function reactivate(selection) {
+                        execBulkAction('reactivate', __('Reactivate Session'), selection, function (sel, reason) {
+                            request('reactivate', sel, { reason: reason }, __('Sessions reactivated'));
+                        });
+                    }
+
+                    // report irregularities on the selected delivery executions
+                    function report(selection) {
+                        if (allowIrr) {
+                            execBulkAction('report', __('Report Irregularity'), selection, function (sel, reason) {
+                                request('report', sel, { reason: reason }, __('Sessions reported'));
+                            });
+                        }
+                    }
+
+                    function terminateOrReactivateAndIrregularity(selection) {
+                        var delivery = getExecutionData(selection);
+                        var buttons = [];
+                        if (hasAccessToReactivate && canDo('reactivate', delivery.state)) {
+                            buttons.push({
+                                id: 'reactivate',
+                                type: 'error',
+                                label: __('Reactivate session'),
+                                icon: 'play',
+                                close: true,
+                                action() {
+                                    reactivate(selection);
                                 }
-                                appController.onError(err);
-                                feedback().error(`${__('Something went wrong ...')}<br>${messageContext}`, {encodeHtml: false});
+                            });
+                        } else if (canDo('terminate', delivery.state)) {
+                            buttons.push({
+                                id: 'terminate',
+                                type: 'error',
+                                label: __('Terminate session'),
+                                icon: 'stop',
+                                close: true,
+                                action() {
+                                    terminate(selection);
+                                }
+                            });
+                        }
+
+                        if (allowIrr) {
+                            buttons.push({
+                                id: 'irregularity',
+                                type: 'info',
+                                label: __('Report irregularity'),
+                                icon: 'delivery-small',
+                                close: true,
+                                action() {
+                                    report(selection);
+                                }
+                            });
+                        }
+
+                        if (buttons.length) {
+                            dialog({
+                                message: __('Please, make your selection'),
+                                autoRender: true,
+                                autoDestroy: true,
+                                buttons: buttons
+                            });
+                        }
+                    }
+
+                    // display the session history
+                    function showHistory(selection) {
+                        var monitoringRoute = window.location.toString();
+                        var urlParams = {
+                            session: selection
+                        };
+                        if (context) {
+                            urlParams.context = context;
+                        }
+                        if (deliveryId) {
+                            urlParams.delivery = deliveryId;
+                        }
+                        appController
+                            .getRouter()
+                            .redirect(urlHelper.build(sessionsHistoryUrl, urlParams))
+                            .then(function () {
+                                appController.trigger('set-referrer', monitoringRoute);
                             })
-                            .then(function() {
-                                loadingBar.stop();
+                            .catch(function (err) {
+                                appController.onError(err);
                             });
                     }
-                }
 
-                // request the server to authorize the selected delivery executions
-                function authorize(selection) {
-                    execBulkAction('authorize', __('Authorize Session'), selection, function(sel, reason){
-                        request('authorize', sel, {reason: reason}, __('Sessions authorized'));
-                    });
-                }
-
-                // request the server to pause the selected delivery executions
-                function pause(selection) {
-                    execBulkAction('pause', __('Pause Session'), selection, function(sel, reason){
-                        request('pause', sel, {reason: reason}, __('Sessions paused'));
-                    });
-                }
-
-                // request the server to terminate the selected delivery executions
-                function terminate(selection) {
-                    execBulkAction('terminate', __('Terminate Session'), selection, function(sel, reason){
-                        request('terminate', sel, {reason: reason}, __('Sessions terminated'));
-                    });
-                }
-
-                // request the reactivate to reactivate the selected delivery executions
-                function reactivate(selection) {
-                    execBulkAction('reactivate', __('Reactivate Session'), selection, function(sel, reason){
-                        request('reactivate', sel, {reason: reason}, __('Sessions reactivated'));
-                    });
-                }
-
-                // report irregularities on the selected delivery executions
-                function report(selection) {
-                    if (allowIrr) {
-                        execBulkAction('report', __('Report Irregularity'), selection, function (sel, reason) {
-                            request('report', sel, {reason: reason}, __('Sessions reported'));
-                        });
-                    }
-                }
-
-                function terminateOrReactivateAndIrregularity(selection) {
-                    var delivery = getExecutionData(selection);
-                    var buttons = [];
-                    if (hasAccessToReactivate && canDo('reactivate', delivery.state)) {
-                        buttons.push({
-                            id: 'reactivate',
-                            type: 'error',
-                            label: __('Reactivate session'),
-                            icon: 'play',
-                            close: true,
-                            action() {
-                                reactivate(selection);
+                    // print the score reports
+                    function printReport(selection) {
+                        execBulkAction('print', __('Print Score'), selection, function (sel) {
+                            var params = { id: sel };
+                            if (context) {
+                                params.context = context;
                             }
-                        });
-                    }else if (canDo('terminate', delivery.state)) {
-                        buttons.push({
-                            id: 'terminate',
-                            type: 'error',
-                            label: __('Terminate session'),
-                            icon: 'stop',
-                            close: true,
-                            action() {
-                                terminate(selection);
-                            }
+                            const url = urlHelper.route(
+                                printReportUrl.action,
+                                printReportUrl.controller,
+                                printReportUrl.extension,
+                                params
+                            );
+                            window.open(url, `printReport${JSON.stringify(sel)}`);
                         });
                     }
 
-                    if (allowIrr) {
-                        buttons.push({
-                            id: 'irregularity',
-                            type: 'info',
-                            label: __('Report irregularity'),
-                            icon: 'delivery-small',
-                            close: true,
-                            action() {
-                                report(selection);
-                            }
+                    function timeHandling(selection) {
+                        const _selection = _.isArray(selection) ? selection : [selection];
+                        const config = _.merge(listSessions('time', _selection), {
+                            renderTo: $content,
+                            actionName: __('Grant Extra Time'),
+                            errorMessage: __('The extra time must be a number'),
+                            unit: extraTimeUnit, // input extra time in minutes
+                            note: __('the already granted time will be replaced by the new value'),
+                            inputLabel: __('Extra time')
+                        });
+
+                        timeHandlingPopup(config).on('ok', function (state) {
+                            request('extraTime', _selection, { time: state.time }, __('Extra time granted'));
                         });
                     }
 
-                    if (buttons.length) {
-                        dialog({
-                            message: __('Please, make your selection'),
-                            autoRender: true,
-                            autoDestroy: true,
-                            buttons: buttons
-                        });
-                    }
-                }
-
-                // display the session history
-                function showHistory(selection) {
-                    var monitoringRoute = window.location.toString();
-                    var urlParams = {
-                        session: selection
-                    };
-                    if (context) {
-                        urlParams.context = context;
-                    }
-                    if (deliveryId) {
-                        urlParams.delivery = deliveryId;
-                    }
-                    appController.getRouter().redirect(urlHelper.build(sessionsHistoryUrl, urlParams)).then(function() {
-                        appController.trigger('set-referrer', monitoringRoute);
-                    }).catch(function(err){
-                        appController.onError(err);
-                    });
-                }
-
-                // print the score reports
-                function printReport(selection) {
-                    execBulkAction('print', __('Print Score'), selection, function(sel) {
-                        var params = { id: sel };
-                        if (context){
-                            params.context = context;
-                        }
-                        const url = urlHelper.route(
-                            printReportUrl.action,
-                            printReportUrl.controller,
-                            printReportUrl.extension,
-                            params
-                        );
-                        window.open(url, `printReport${JSON.stringify(sel)}`);
-                    });
-                }
-
-                function timeHandling(selection) {
-                    const _selection = _.isArray(selection) ? selection : [selection];
-                    const config = _.merge(listSessions('time', _selection), {
-                        renderTo : $content,
-                        actionName : __('Grant Extra Time'),
-                        errorMessage: __('The extra time must be a number'),
-                        unit: extraTimeUnit, // input extra time in minutes
-                        note: __('the already granted time will be replaced by the new value'),
-                        inputLabel: __('Extra time'),
-                    });
-
-                    timeHandlingPopup(config).on('ok', function(state){
-                        request('extraTime', _selection, {time: state.time}, __('Extra time granted'));
-                    });
-                }
-
-                // display the time adjustment popup
-                function timeAdjustment(selection) {
-                    const _selection = _.isArray(selection) ? selection : [selection];
-                    const sessionsList = listSessions('changeTime', _selection);
-                    const actionName = 'timeAdjustment';
-                    const askForReason = (categories[actionName] && categories[actionName].categoriesDefinitions && categories[actionName].categoriesDefinitions.length);
-                    const config = Object.assign(
-                        {},
-                        sessionsList,
-                        {
+                    // display the time adjustment popup
+                    function timeAdjustment(selection) {
+                        const _selection = _.isArray(selection) ? selection : [selection];
+                        const sessionsList = listSessions('changeTime', _selection);
+                        const actionName = 'timeAdjustment';
+                        const askForReason =
+                            categories[actionName] &&
+                            categories[actionName].categoriesDefinitions &&
+                            categories[actionName].categoriesDefinitions.length;
+                        const config = Object.assign({}, sessionsList, {
                             renderTo: $content,
                             actionName: __('Change time'),
                             errorMessage: __('The extra time must be a number bigger than 0'),
@@ -437,270 +461,323 @@ define([
                             note: __('Already changed time will be added or subtracted by the new value.'),
                             inputLabel: __('Change time'),
                             changeTimeMode: true,
-                            reason : askForReason,
-                            reasonRequired: true,
-                        },
-                    );
+                            reason: askForReason,
+                            reasonRequired: true
+                        });
 
-                    if (!_.isEmpty(categories[actionName])) {
-                        config.categoriesSelector = cascadingComboBox(categories[actionName]);
-                    }
+                        if (!_.isEmpty(categories[actionName])) {
+                            config.categoriesSelector = cascadingComboBox(categories[actionName]);
+                        }
 
-                    const deliveryExecutionData = getExecutionData(selection);
+                        const deliveryExecutionData = getExecutionData(selection);
 
-                    if (deliveryExecutionData.hasOwnProperty('lastPauseReason')) {
-                        config['predefinedReason'] = deliveryExecutionData['lastPauseReason'];
-                    }
-                    timeHandlingPopup(config)
-                        .on('ok', (state) => {
+                        if (deliveryExecutionData.hasOwnProperty('lastPauseReason')) {
+                            config['predefinedReason'] = deliveryExecutionData['lastPauseReason'];
+                        }
+                        timeHandlingPopup(config).on('ok', state => {
                             request(
                                 'adjustTime',
                                 sessionsList.allowedResources.map(({ id }) => id),
                                 state,
-                                __('Time adjusted'),
+                                __('Time adjusted')
                             );
                         });
-                }
-
-                /**
-                 * Check if an action is available with respect to the provided state
-                 * @param {String} what
-                 * @param {Object} state
-                 * @returns {Boolean}
-                 */
-                function canDo(what, state) {
-                    var status;
-                    if (state && state.status) {
-                        status = _status.getStatusByCode(state.status);
-                        return status && status.can[what] === true;
                     }
-                    return false;
-                }
 
-                /**
-                 * Verify and reformat test taker data for the execBulkAction's need
-                 * @param {Object} testTakerData
-                 * @param {String} actionName
-                 * @returns {Object}
-                 */
-                function verifyDelivery(testTakerData, actionName){
-                    var deliveryName, formatted, status;
-
-                    if (_.isObject(testTakerData.delivery)) {
-                        deliveryName = testTakerData.delivery.label;
-                    } else {
-                        deliveryName = testTakerData.delivery;
-                    }
-                    //decode all accent character
-                    deliveryName = $("<div/>").html(deliveryName).text();
-                    formatted = {
-                        id : testTakerData.id,
-                        label: `${deliveryName} [${testTakerData.start_time}] ${testTakerData.test_taker_first_name} ${testTakerData.test_taker_last_name}`
-                    };
-                    status = _status.getStatusByCode(testTakerData.state.status);
-
-                    if(status){
-                        formatted.allowed = (status.can[actionName] === true);
-
-                        if (actionName === 'changeTime') {
-                            formatted.allowed = testTakerData.allowTimerAdjustment;
+                    /**
+                     * Check if an action is available with respect to the provided state
+                     * @param {String} what
+                     * @param {Object} state
+                     * @returns {Boolean}
+                     */
+                    function canDo(what, state) {
+                        var status;
+                        if (state && state.status) {
+                            status = _status.getStatusByCode(state.status);
+                            return status && status.can[what] === true;
                         }
+                        return false;
+                    }
 
-                        if(!formatted.allowed){
-                            formatted.reason = status.can[actionName];
-                            formatted.warning = status.warning[actionName] ?
-                                status.warning[actionName](null, testTakerData.id) :
-                                __('Unable to perform action on test %s.', testTakerData.id);
+                    /**
+                     * Verify and reformat test taker data for the execBulkAction's need
+                     * @param {Object} testTakerData
+                     * @param {String} actionName
+                     * @returns {Object}
+                     */
+                    function verifyDelivery(testTakerData, actionName) {
+                        var deliveryName, formatted, status;
+
+                        if (_.isObject(testTakerData.delivery)) {
+                            deliveryName = testTakerData.delivery.label;
+                        } else {
+                            deliveryName = testTakerData.delivery;
                         }
-                    }
-                    if (testTakerData.timer) {
-                        formatted.extraTime = testTakerData.timer.extraTime;
-                        formatted.consumedTime = testTakerData.timer.consumedExtraTime;
-                        formatted.remaining_time = testTakerData.timer.remaining_time;
-                    }
-                    return formatted;
-                }
+                        //decode all accent character
+                        deliveryName = $('<div/>').html(deliveryName).text();
+                        formatted = {
+                            id: testTakerData.id,
+                            label: `${deliveryName} [${testTakerData.start_time}] ${testTakerData.test_taker_first_name} ${testTakerData.test_taker_last_name}`
+                        };
+                        status = _status.getStatusByCode(testTakerData.state.status);
 
-                /**
-                 * Find the execution row data from its uri
-                 *
-                 * @param {String} uri
-                 * @returns {Object}
-                 */
-                function getExecutionData(uri){
-                    return _.find(dataset.data, {id : uri});
-                }
+                        if (status) {
+                            formatted.allowed = status.can[actionName] === true;
 
-                /**
-                 * Gets the list of allowed and forbidden test sessions from the provided selection
-                 * @param {String} actionName
-                 * @param {Array} selection
-                 * @returns {Object} Returns the config object that contains the lists of allowed and forbidden test sessions
-                 */
-                function listSessions(actionName, selection) {
-                    var allowedDeliveries = [];
-                    var forbiddenDeliveries = [];
+                            if (actionName === 'changeTime') {
+                                formatted.allowed = testTakerData.allowTimerAdjustment;
+                            }
 
-                    _.each(selection, function (uri) {
-                        var testTakerData = getExecutionData(uri);
-                        var checkedDelivery;
-                        if(testTakerData){
-                            checkedDelivery = verifyDelivery(testTakerData, actionName);
-                            if(checkedDelivery.allowed){
-                                allowedDeliveries.push(checkedDelivery);
-                            }else{
-                                forbiddenDeliveries.push(checkedDelivery);
+                            if (!formatted.allowed) {
+                                formatted.reason = status.can[actionName];
+                                formatted.warning = status.warning[actionName]
+                                    ? status.warning[actionName](null, testTakerData.id)
+                                    : __('Unable to perform action on test %s.', testTakerData.id);
                             }
                         }
-                    });
-
-                    return {
-                        resourceType : __('session'),
-                        resourceTypes: __('sessions'),
-                        allowedResources: allowedDeliveries,
-                        deniedResources: forbiddenDeliveries
-                    };
-                }
-
-                /**
-                 * Exec
-                 * @param {String} actionName
-                 * @param {String} actionTitle
-                 * @param {Array|String} selection
-                 * @param {Function} cb
-                 * @returns {undefined}
-                 */
-                function execBulkAction(actionName, actionTitle, selection, cb){
-                    var _selection = _.isArray(selection) ? selection : [selection];
-                    var askForReason = (categories[actionName] && categories[actionName].categoriesDefinitions && categories[actionName].categoriesDefinitions.length);
-                    var config = _.merge(listSessions(actionName, _selection), {
-                        renderTo : $content,
-                        actionName : actionTitle,
-                        reason : askForReason,
-                        reasonRequired: true,
-                    });
-
-                    if (dialogSettings && dialogSettings[actionName]) {
-                        config.message = dialogSettings[actionName].message;
-                        config.icon = dialogSettings[actionName].icon;
+                        if (testTakerData.timer) {
+                            formatted.extraTime = testTakerData.timer.extraTime;
+                            formatted.consumedTime = testTakerData.timer.consumedExtraTime;
+                            formatted.remaining_time = testTakerData.timer.remaining_time;
+                        }
+                        return formatted;
                     }
 
-                    if (!_.isEmpty(categories[actionName])) {
-                        config.categoriesSelector = cascadingComboBox(categories[actionName]);
+                    /**
+                     * Find the execution row data from its uri
+                     *
+                     * @param {String} uri
+                     * @returns {Object}
+                     */
+                    function getExecutionData(uri) {
+                        return _.find(dataset.data, { id: uri });
                     }
 
-                    if (!config.allowedResources.length) {
-                        feedback().warning(_status.buildWarningMessage(actionName, _selection, config.deniedResources));
-                    } else {
-                        bulkActionPopup(config).on('ok', function(reason){
-                            //execute callback
-                            if(_.isFunction(cb)){
-                                cb(config.allowedResources.map(res => res.id), reason);
+                    /**
+                     * Gets the list of allowed and forbidden test sessions from the provided selection
+                     * @param {String} actionName
+                     * @param {Array} selection
+                     * @returns {Object} Returns the config object that contains the lists of allowed and forbidden test sessions
+                     */
+                    function listSessions(actionName, selection) {
+                        var allowedDeliveries = [];
+                        var forbiddenDeliveries = [];
+
+                        _.each(selection, function (uri) {
+                            var testTakerData = getExecutionData(uri);
+                            var checkedDelivery;
+                            if (testTakerData) {
+                                checkedDelivery = verifyDelivery(testTakerData, actionName);
+                                if (checkedDelivery.allowed) {
+                                    allowedDeliveries.push(checkedDelivery);
+                                } else {
+                                    forbiddenDeliveries.push(checkedDelivery);
+                                }
                             }
                         });
+
+                        return {
+                            resourceType: __('session'),
+                            resourceTypes: __('sessions'),
+                            allowedResources: allowedDeliveries,
+                            deniedResources: forbiddenDeliveries
+                        };
                     }
-                }
 
-                /**
-                 * Return html for filter
-                 * @returns {String}
-                 */
-                function buildStatusFilter(){
-                    return statusFilterTpl({statuses: _status.getStatuses()});
-                }
+                    /**
+                     * Exec
+                     * @param {String} actionName
+                     * @param {String} actionTitle
+                     * @param {Array|String} selection
+                     * @param {Function} cb
+                     * @returns {undefined}
+                     */
+                    function execBulkAction(actionName, actionTitle, selection, cb) {
+                        var _selection = _.isArray(selection) ? selection : [selection];
+                        var askForReason =
+                            categories[actionName] &&
+                            categories[actionName].categoriesDefinitions &&
+                            categories[actionName].categoriesDefinitions.length;
+                        var config = _.merge(listSessions(actionName, _selection), {
+                            renderTo: $content,
+                            actionName: actionTitle,
+                            reason: askForReason,
+                            reasonRequired: true
+                        });
 
-                /**
-                 * Prepare data to be sent on server + internal state saving
-                 * @param {Boolean} applyTags
-                 */
-                function setTagUsage(applyTags) {
-                    var $filter;
-                    if (defaultTag) {
-
-                        if (!$list.find('.tag').length) {
-                            $filter = $(`<span class="filter"><input type="hidden" name="tag" class="tag" value="${applyTags}"/></span>`);
-                            $filter.appendTo($list);
+                        if (dialogSettings && dialogSettings[actionName]) {
+                            config.message = dialogSettings[actionName].message;
+                            config.icon = dialogSettings[actionName].icon;
                         }
 
-                        $list.find('.tag').val(applyTags);
-                        $list.data('applytags', applyTags);
+                        if (!_.isEmpty(categories[actionName])) {
+                            config.categoriesSelector = cascadingComboBox(categories[actionName]);
+                        }
 
-                        if (applyTags) {
-                            $list.find('.action-bar').children('.tool-tag').hide();
+                        if (!config.allowedResources.length) {
+                            feedback().warning(
+                                _status.buildWarningMessage(actionName, _selection, config.deniedResources)
+                            );
                         } else {
-                            $list.find('.action-bar').children('.tool-notag').hide();
+                            bulkActionPopup(config).on('ok', function (reason) {
+                                //execute callback
+                                if (_.isFunction(cb)) {
+                                    cb(
+                                        config.allowedResources.map(res => res.id),
+                                        reason
+                                    );
+                                }
+                            });
                         }
                     }
-                }
 
-                function getTagsUsage() {
-                    return $list.data('applytags');
-                }
-
-                /**
-                 * Set initial datatable filters
-                 */
-                function setInitialFilters() {
-                    if (defaultTag) {
-                        setTagUsage(true);
+                    /**
+                     * Return html for filter
+                     * @returns {String}
+                     */
+                    function buildStatusFilter() {
+                        return statusFilterTpl({ statuses: _status.getStatuses() });
                     }
-                }
 
-                /**
-                 * Additional action perfomed with filter element
-                 * @param {jQueryElement} $el
-                 */
-                function statusFilterHandler($el) {
-                    $el.select2({
-                        dropdownAutoWidth: true,
-                        placeholder: __('Filter'),
-                        minimumResultsForSearch: Infinity,
-                        allowClear: true
-                    });
-                }
+                    /**
+                     * Prepare data to be sent on server + internal state saving
+                     * @param {Boolean} applyTags
+                     */
+                    function setTagUsage(applyTags) {
+                        var $filter;
+                        if (defaultTag) {
+                            if (!$list.find('.tag').length) {
+                                $filter = $(
+                                    `<span class="filter"><input type="hidden" name="tag" class="tag" value="${applyTags}"/></span>`
+                                );
+                                $filter.appendTo($list);
+                            }
 
-                /**
-                 * Return the default date range of one day
-                 * @returns {string}
-                 */
-                function getDefaultStartTimeFilter() {
-                    var dateFormat = locale.getDateTimeFormat().split(' ')[0];
-                    return `${moment().format(dateFormat)} to ${moment().add('1', 'd').format(dateFormat)}`;
-                }
+                            $list.find('.tag').val(applyTags);
+                            $list.data('applytags', applyTags);
 
-                function extractOption(object, option, defaultValue) {
-                    return _.isUndefined(object[option], undefined) ? defaultValue : object[option];
-                }
+                            if (applyTags) {
+                                $list.find('.action-bar').children('.tool-tag').hide();
+                            } else {
+                                $list.find('.action-bar').children('.tool-notag').hide();
+                            }
+                        }
+                    }
 
-                if (deliveryId) {
-                    serviceParams.delivery = deliveryId;
-                }
-                if (context) {
-                    serviceParams.context = context;
-                }
+                    function getTagsUsage() {
+                        return $list.data('applytags');
+                    }
 
-                return proxyExecutions.read(serviceParams).then(function(data) {
-                    dataset = data.set;
-                    extraFields = data.extrafields;
-                    categories = data.categories;
-                    deliveryId = data.delivery || deliveryId;
-                    context = data.context || context;
-                    timeHandlingMode = data.timeHandling === 'extra_time';
-                    changeTimeMode = data.timeHandling === 'timer_adjustment';
-                    allowedConnectivity = data.onlineStatus || false;
-                    printReportButton = data.printReportButton;
-                    printReportUrl = data.printReportUrl;
-                    hasAccessToReactivate = data.hasAccessToReactivate;
-                    sessionsHistoryUrl = data.historyUrl || historyUrl;
-                    dialogSettings = data.dialogSettings;
+                    /**
+                     * Set initial datatable filters
+                     */
+                    function setInitialFilters() {
+                        if (defaultTag) {
+                            setTagUsage(true);
+                        }
+                    }
 
-                    var showColumnFirstName = extractOption(data, 'showColumnFirstName', true);
-                    var showColumnLastName = extractOption(data, 'showColumnLastName', true);
-                    var showColumnAuthorize = extractOption(data, 'showColumnAuthorize', true);
-                    var showColumnRemainingTime = extractOption(data, 'showColumnRemainingTime', true);
-                    var showColumnExtendedTime = extractOption(data, 'showColumnExtendedTime', true);
-                    var showActionShowHistory = extractOption(data, 'showActionShowHistory', true);
-                    var setStartDataOneDay = extractOption(data, 'setStartDataOneDay', true);
+                    /**
+                     * Additional action perfomed with filter element
+                     * @param {jQueryElement} $el
+                     */
+                    function statusFilterHandler($el) {
+                        $el.select2({
+                            dropdownAutoWidth: true,
+                            placeholder: __('Filter'),
+                            minimumResultsForSearch: Infinity,
+                            allowClear: true
+                        });
+                    }
+
+                    /**
+                     * Return the default date range of one day
+                     * @returns {string}
+                     */
+                    function getDefaultStartTimeFilter() {
+                        var dateFormat = locale.getDateTimeFormat().split(' ')[0];
+                        return `${moment().format(dateFormat)} to ${moment().add('1', 'd').format(dateFormat)}`;
+                    }
+
+                    function extractOption(object, option, defaultValue) {
+                        return _.isUndefined(object[option], undefined) ? defaultValue : object[option];
+                    }
+
+                    /**
+                     * Compare data responses
+                     * @param {*} response
+                     * @param {*} savedResponse
+                     */
+                    function isReponseDataChanged(response, savedResponse) {
+                        if (_.has(response, 'data') && _.has(savedResponse, 'data')) {
+                            const newData = response.data;
+                            const savedData = savedResponse.data;
+
+                            if (_.isArray(newData) && _.isArray(savedData)) {
+                                let newDataSize = _.size(newData);
+                                let savedDataSize = _.size(savedData);
+
+                                if (newDataSize !== savedDataSize) {
+                                    return true;
+                                }
+
+                                // We have to exlude the timer property from comparising since
+                                // the values for that property are always changed when test is in progress state
+                                const omitPropertiesToBeCompare = ['timer'];
+
+                                while (newDataSize--) {
+                                    let isDataEqual = _.isEqual(
+                                        _.omit(newData[newDataSize], omitPropertiesToBeCompare),
+                                        _.omit(savedData[newDataSize], omitPropertiesToBeCompare)
+                                    );
+
+                                    if (!isDataEqual) {
+                                        return true;
+                                    }
+                                }
+                                return false;
+                            }
+                        }
+
+                        return _.isEqual(response, savedResponse);
+                    }
+
+                    function startPollingData(data, ajaxConfig) {
+                        const isPollingAvaible = data.autoRefresh && ajaxConfig;
+
+                        stopPollingData();
+
+                        if (!isPollingAvaible) {
+                            return;
+                        }
+
+                        dataPolling.setAction(function (proccess) {
+                            const action = proccess.async();
+
+                            $.ajax(ajaxConfig)
+                                .then(response => {
+                                    try {
+                                        const shouldRefreshDataTable = isReponseDataChanged(response, originalDataset);
+
+                                        console.log('shouldRefreshDataTable', shouldRefreshDataTable);
+                                        if (shouldRefreshDataTable) {
+                                            console.log('refresh');
+                                            $list.datatable('refresh', response);
+                                        }
+                                    } finally {
+                                        action.resolve();
+                                    }
+                                })
+                                .fail(action.resolve);
+                        });
+
+                        dataPolling.setInterval(data.autoRefresh);
+                        dataPolling.start();
+                    }
+
+                    function stopPollingData() {
+                        dataPolling.stop();
+                    }
 
                     if (deliveryId) {
                         serviceParams.delivery = deliveryId;
@@ -709,582 +786,643 @@ define([
                         serviceParams.context = context;
                     }
 
-                    /**
-                     * configurable parameter to show button
-                     */
-                    if (data.refreshBtn) {
-                        // tool: page refresh
-                        tools.push({
-                            id: 'refresh',
-                            icon: 'reset',
-                            title: __('Refresh the page'),
-                            label: __('Refresh'),
-                            action() {
-                                $list.datatable('refresh');
-                            }
-                        });
-                    }
+                    return proxyExecutions.read(serviceParams).then(function (data) {
+                        dataset = data.set;
+                        extraFields = data.extrafields;
+                        categories = data.categories;
+                        deliveryId = data.delivery || deliveryId;
+                        context = data.context || context;
+                        timeHandlingMode = data.timeHandling === 'extra_time';
+                        changeTimeMode = data.timeHandling === 'timer_adjustment';
+                        allowedConnectivity = data.onlineStatus || false;
+                        printReportButton = data.printReportButton;
+                        printReportUrl = data.printReportUrl;
+                        hasAccessToReactivate = data.hasAccessToReactivate;
+                        sessionsHistoryUrl = data.historyUrl || historyUrl;
+                        dialogSettings = data.dialogSettings;
 
-                    /**
-                     * Configurable parameter to auto renew datatable
-                     */
-                    if (data.autoRefresh) {
-                        setInterval(function () {
-                            $list.datatable('refresh');
-                        }, data.autoRefresh);
-                    }
+                        var showColumnFirstName = extractOption(data, 'showColumnFirstName', true);
+                        var showColumnLastName = extractOption(data, 'showColumnLastName', true);
+                        var showColumnAuthorize = extractOption(data, 'showColumnAuthorize', true);
+                        var showColumnRemainingTime = extractOption(data, 'showColumnRemainingTime', true);
+                        var showColumnExtendedTime = extractOption(data, 'showColumnExtendedTime', true);
+                        var showActionShowHistory = extractOption(data, 'showActionShowHistory', true);
+                        var setStartDataOneDay = extractOption(data, 'setStartDataOneDay', true);
 
-                    if (defaultTag) {
-                        tools.push({
-                            id: 'notag',
-                            icon: 'filter',
-                            css: 'btn-warning',
-                            label: __('Remove default tag filtering'),
-                            title: __('Remove default tag filtering'),
-                            action() {
-                                setTagUsage(false);
-                                $list.datatable('filter');
-                            }
-                        });
-                        tools.push({
-                            id: 'tag',
-                            icon: 'filter',
-                            title: __('Apply default tag'),
-                            label: __('Apply default tag'),
-                            action() {
-                                setTagUsage(true);
-                                $list.datatable('filter');
-                            }
-                        });
-                    }
-
-                    // tool: authorize the executions
-                    tools.push({
-                        id: 'authorize',
-                        icon: 'play',
-                        title: __('Authorize sessions'),
-                        label: __('Authorize'),
-                        massAction: true,
-                        action: authorize
-                    });
-
-                    if(data.canPause === null || data.canPause){
-                        // tool: pause the executions
-                        tools.push({
-                            id: 'pause',
-                            icon: 'pause',
-                            title: __('Pause sessions'),
-                            label: __('Pause'),
-                            massAction: true,
-                            action: pause
-                        });
-                    }
-
-                    // tool: terminate the executions
-                    tools.push({
-                        id: 'terminate',
-                        icon: 'stop',
-                        title: __('Terminate sessions'),
-                        label: __('Terminate'),
-                        massAction: true,
-                        action: terminate
-                    });
-
-                    if (allowIrr) {
-                        // tool: report irregularities
-                        tools.push({
-                            id: 'irregularity',
-                            icon: 'delivery-small',
-                            title: __('Report irregularities'),
-                            label: __('Report'),
-                            massAction: true,
-                            action: report
-                        });
-                    }
-
-                    // tools: print results
-                    if (printReportButton) {
-                        tools.push({
-                            id : 'printReport',
-                            title : __('Print the assessment results'),
-                            icon : 'result',
-                            label : __('Print Results'),
-                            massAction: true,
-                            action : printReport
-                        });
-                    }
-
-                    // tools: handles the session time
-                    if (timeHandlingMode) {
-                        tools.push({
-                            id : 'timeHandling',
-                            title : __('Session time handling'),
-                            icon : 'time',
-                            label : __('Time'),
-                            massAction: true,
-                            action : timeHandling
-                        });
-                    }
-
-                    // tools: adjust the session time
-                    if (changeTimeMode) {
-                        tools.push({
-                            id : 'timeAdjustment',
-                            title : __('Session time handling'),
-                            icon : 'time',
-                            label : __('Time'),
-                            massAction: true,
-                            action : timeAdjustment,
-                        });
-                    }
-
-                    // column: delivery (only for all deliveries view)
-                    model.push({
-                        id: 'deliveryLabel',
-                        label: __('Session'),
-                        sortable : true,
-                        transform(value, row) {
-                            var delivery = row && row.delivery;
-                            if (delivery) {
-                                value = deliveryLinkTpl(delivery);
-                            }
-                            return value;
+                        if (deliveryId) {
+                            serviceParams.delivery = deliveryId;
                         }
-                    });
-
-                    // column: test taker first name
-                    if (showColumnFirstName) {
-                        model.push({
-                            id: 'test_taker_first_name',
-                            label: __('First name'),
-                            filterable: true,
-                            sortable: true,
-                            transform(value, row) {
-                                return row && row.testTaker && row.testTaker.test_taker_first_name || '';
-                            }
-                        });
-                    }
-
-                    // column: test taker last name
-                    if (showColumnLastName) {
-                        model.push({
-                            id: 'test_taker_last_name',
-                            label: __('Last name'),
-                            filterable: true,
-                            sortable: true,
-                            transform(value, row) {
-                                return row && row.testTaker && row.testTaker.test_taker_last_name || '';
-                            }
-                        });
-                    }
-
-                    //extra fields
-                    _.each(extraFields, function(extraField){
-                        model.push({
-                            id : extraField.id,
-                            label: extraField.label,
-                            filterable: extraField.filterable,
-                            sortable : true,
-                            order: extraField.columnPosition,
-                            transform(value, row) {
-                                return row && row.extraFields && row.extraFields[extraField.id] || '';
-                            }
-                        });
-                    });
-
-                    // column: start time
-                    model.push({
-                        id: 'start_time',
-                        sortable: true,
-                        label: __('Started at'),
-                        filterable : true,
-                        transform(value) {
-                            return locale.formatDateTime(value);
-                        },
-                        filterTransform(value) {
-                            var first;
-                            var last;
-                            var dateFormat = locale.getDateTimeFormat().split(' ')[0];
-                            var values = value.split(' ');
-                            var result = '';
-
-                            if (values.length >= 2) {
-                                first = values[0];
-                                last = values[values.length - 1];
-
-                                result += moment(first, dateFormat).format('X');
-                                result += ' - ';
-                                result += moment(last, dateFormat).add(1, 'd').format('X');
-                            }
-
-                            return result;
-                        },
-                        customFilter : {
-                            template : `<input type="text" id="start_time_filter" name="filter[start_time]" placeholder="${__('Filter')}"/>`,
-                            callback($elt) {
-                                var $filterContainer = $elt.closest('.filter');
-                                var dateFormat = locale.getDateTimeFormat().split(' ');
-                                var dateFormatStr = dateFormat[0];
-                                var lastValue;
-
-                                // the date time picker won't display otherwise
-                                $filterContainer.css('position', 'static');
-
-                                if (startDatePicker) {
-                                    startDatePicker.destroy();
-                                }
-
-                                startDatePicker = dateTimePicker($filterContainer, {
-                                    setup: 'datetime-range',
-                                    format: dateFormatStr,
-                                    replaceField: $elt[0]
-                                })
-                                    .on('change', function (value) {
-                                        var selection = this.getSelectedDates();
-                                        if ((value === '' && lastValue !== value) ||
-                                            (selection && selection.length === 2)) {
-                                            $list.datatable('filter');
-                                        }
-                                        lastValue = value;
-                                    })
-                                    .on('clear', function () {
-                                        $list.datatable('filter');
-                                    });
-                            }
-                        },
-                    });
-
-                    // column: delivery execution status
-                    model.push({
-                        id: 'status',
-                        label: __('Status'),
-                        sortable: true,
-                        filterable: true,
-                        customFilter: {
-                            template: buildStatusFilter(),
-                            callback: statusFilterHandler
-                        },
-
-                        transform(value, row) {
-                            var result = '',
-                                status;
-
-                            if (row && row.state && row.state.status) {
-                                status = _status.getStatusByCode(row.state.status);
-                                if (status) {
-                                    result = status.label;
-                                    if (row.state.status === 'INPROGRESS') {
-                                        result = status.label;
-                                    }
-                                    if (result === 'Awaiting') {
-                                        highlightRows.push(row.id);
-                                    }
-                                }
-                            }
-                            return result;
+                        if (context) {
+                            serviceParams.context = context;
                         }
-                    });
 
-                    // action: authorize the execution
-                    if (showColumnAuthorize) {
-                        model.push({
-                            id: 'authorizeCl',
+                        /**
+                         * configurable parameter to show button
+                         */
+                        if (data.refreshBtn) {
+                            // tool: page refresh
+                            tools.push({
+                                id: 'refresh',
+                                icon: 'reset',
+                                title: __('Refresh the page'),
+                                label: __('Refresh'),
+                                action() {
+                                    $list.datatable('refresh', {});
+                                }
+                            });
+                        }
+
+                        if (defaultTag) {
+                            tools.push({
+                                id: 'notag',
+                                icon: 'filter',
+                                css: 'btn-warning',
+                                label: __('Remove default tag filtering'),
+                                title: __('Remove default tag filtering'),
+                                action() {
+                                    setTagUsage(false);
+                                    $list.datatable('filter');
+                                }
+                            });
+                            tools.push({
+                                id: 'tag',
+                                icon: 'filter',
+                                title: __('Apply default tag'),
+                                label: __('Apply default tag'),
+                                action() {
+                                    setTagUsage(true);
+                                    $list.datatable('filter');
+                                }
+                            });
+                        }
+
+                        // tool: authorize the executions
+                        tools.push({
+                            id: 'authorize',
+                            icon: 'play',
+                            title: __('Authorize sessions'),
                             label: __('Authorize'),
-                            type: 'actions',
-                            actions: [{
-                                id: 'authorize',
-                                icon: 'play',
-                                title: __('Authorize session'),
-                                disabled() {
-                                    return !canDo('authorize', this.state);
-                                },
-                                action: authorize
-                            }]
+                            massAction: true,
+                            action: authorize
                         });
-                    }
 
-                    if(data.canPause === null || data.canPause) {
-                        // action: pause the execution
-                        model.push({
-                            id: 'pauseCl',
-                            label: __('Pause'),
-                            type: 'actions',
-                            actions: [{
+                        if (data.canPause === null || data.canPause) {
+                            // tool: pause the executions
+                            tools.push({
                                 id: 'pause',
                                 icon: 'pause',
-                                title: __('Pause session'),
-                                disabled() {
-                                    return !canDo('pause', this.state);
-                                },
+                                title: __('Pause sessions'),
+                                label: __('Pause'),
+                                massAction: true,
                                 action: pause
-                            }]
+                            });
+                        }
+
+                        // tool: terminate the executions
+                        tools.push({
+                            id: 'terminate',
+                            icon: 'stop',
+                            title: __('Terminate sessions'),
+                            label: __('Terminate'),
+                            massAction: true,
+                            action: terminate
                         });
-                    }
 
-                    // column: remaining time
-                    if (showColumnRemainingTime) {
+                        if (allowIrr) {
+                            // tool: report irregularities
+                            tools.push({
+                                id: 'irregularity',
+                                icon: 'delivery-small',
+                                title: __('Report irregularities'),
+                                label: __('Report'),
+                                massAction: true,
+                                action: report
+                            });
+                        }
+
+                        // tools: print results
+                        if (printReportButton) {
+                            tools.push({
+                                id: 'printReport',
+                                title: __('Print the assessment results'),
+                                icon: 'result',
+                                label: __('Print Results'),
+                                massAction: true,
+                                action: printReport
+                            });
+                        }
+
+                        // tools: handles the session time
+                        if (timeHandlingMode) {
+                            tools.push({
+                                id: 'timeHandling',
+                                title: __('Session time handling'),
+                                icon: 'time',
+                                label: __('Time'),
+                                massAction: true,
+                                action: timeHandling
+                            });
+                        }
+
+                        // tools: adjust the session time
+                        if (changeTimeMode) {
+                            tools.push({
+                                id: 'timeAdjustment',
+                                title: __('Session time handling'),
+                                icon: 'time',
+                                label: __('Time'),
+                                massAction: true,
+                                action: timeAdjustment
+                            });
+                        }
+
+                        // column: delivery (only for all deliveries view)
                         model.push({
-                            id: 'remaining_time',
+                            id: 'deliveryLabel',
+                            label: __('Session'),
                             sortable: true,
-                            sorttype: 'numeric',
-                            label: __('Remaining'),
                             transform(value, row) {
-                                var rowTimer = _.isObject(row.timer) ? row.timer : {};
-                                var refinedValue = rowTimer.approximatedRemaining ? rowTimer.approximatedRemaining : rowTimer.remaining_time;
-                                var remaining = parseInt(refinedValue, 10);
-                                if (remaining || _.isFinite(remaining)) {
-                                    if (remaining < 0) {
-                                        if (rowTimer.extraTime && rowTimer.consumedExtraTime) {
-                                            rowTimer.consumedExtraTime += -remaining;
-                                        }
-                                        remaining = 0;
-                                    }
-                                    if (remaining) {
-                                        if (rowTimer.extraTime && rowTimer.consumedExtraTime) {
-                                            remaining -= rowTimer.consumedExtraTime;
-                                        }
-                                        refinedValue = timeEncoder.encode(remaining);
-                                    } else {
-                                        refinedValue = '';
+                                var delivery = row && row.delivery;
+                                if (delivery) {
+                                    value = deliveryLinkTpl(delivery);
+                                }
+                                return value;
+                            }
+                        });
+
+                        // column: test taker first name
+                        if (showColumnFirstName) {
+                            model.push({
+                                id: 'test_taker_first_name',
+                                label: __('First name'),
+                                filterable: true,
+                                sortable: true,
+                                transform(value, row) {
+                                    return (row && row.testTaker && row.testTaker.test_taker_first_name) || '';
+                                }
+                            });
+                        }
+
+                        // column: test taker last name
+                        if (showColumnLastName) {
+                            model.push({
+                                id: 'test_taker_last_name',
+                                label: __('Last name'),
+                                filterable: true,
+                                sortable: true,
+                                transform(value, row) {
+                                    return (row && row.testTaker && row.testTaker.test_taker_last_name) || '';
+                                }
+                            });
+                        }
+
+                        //extra fields
+                        _.each(extraFields, function (extraField) {
+                            model.push({
+                                id: extraField.id,
+                                label: extraField.label,
+                                filterable: extraField.filterable,
+                                sortable: true,
+                                order: extraField.columnPosition,
+                                transform(value, row) {
+                                    return (row && row.extraFields && row.extraFields[extraField.id]) || '';
+                                }
+                            });
+                        });
+
+                        // column: start time
+                        model.push({
+                            id: 'start_time',
+                            sortable: true,
+                            label: __('Started at'),
+                            filterable: true,
+                            transform(value) {
+                                return locale.formatDateTime(value);
+                            },
+                            filterTransform(value) {
+                                var first;
+                                var last;
+                                var dateFormat = locale.getDateTimeFormat().split(' ')[0];
+                                var values = value.split(' ');
+                                var result = '';
+
+                                if (values.length >= 2) {
+                                    first = values[0];
+                                    last = values[values.length - 1];
+
+                                    result += moment(first, dateFormat).format('X');
+                                    result += ' - ';
+                                    result += moment(last, dateFormat).add(1, 'd').format('X');
+                                }
+
+                                return result;
+                            },
+                            customFilter: {
+                                template: `<input type="text" id="start_time_filter" name="filter[start_time]" placeholder="${__(
+                                    'Filter'
+                                )}"/>`,
+                                callback($elt) {
+                                    var $filterContainer = $elt.closest('.filter');
+                                    var dateFormat = locale.getDateTimeFormat().split(' ');
+                                    var dateFormatStr = dateFormat[0];
+                                    var lastValue;
+
+                                    // the date time picker won't display otherwise
+                                    $filterContainer.css('position', 'static');
+
+                                    if (startDatePicker) {
+                                        startDatePicker.destroy();
                                     }
 
-                                    refinedValue = approximatedTimerTpl({
-                                        timer: refinedValue,
-                                        remaining: remaining,
-                                        countDown: rowTimer.countDown
+                                    startDatePicker = dateTimePicker($filterContainer, {
+                                        setup: 'datetime-range',
+                                        format: dateFormatStr,
+                                        replaceField: $elt[0]
+                                    })
+                                        .on('change', function (value) {
+                                            var selection = this.getSelectedDates();
+                                            if (
+                                                (value === '' && lastValue !== value) ||
+                                                (selection && selection.length === 2)
+                                            ) {
+                                                $list.datatable('filter');
+                                            }
+                                            lastValue = value;
+                                        })
+                                        .on('clear', function () {
+                                            $list.datatable('filter');
+                                        });
+                                }
+                            }
+                        });
+
+                        // column: delivery execution status
+                        model.push({
+                            id: 'status',
+                            label: __('Status'),
+                            sortable: true,
+                            filterable: true,
+                            customFilter: {
+                                template: buildStatusFilter(),
+                                callback: statusFilterHandler
+                            },
+
+                            transform(value, row) {
+                                var result = '',
+                                    status;
+
+                                if (row && row.state && row.state.status) {
+                                    status = _status.getStatusByCode(row.state.status);
+                                    if (status) {
+                                        result = status.label;
+                                        if (row.state.status === 'INPROGRESS') {
+                                            result = status.label;
+                                        }
+                                        if (result === 'Awaiting') {
+                                            highlightRows.push(row.id);
+                                        }
+                                    }
+                                }
+                                return result;
+                            }
+                        });
+
+                        // action: authorize the execution
+                        if (showColumnAuthorize) {
+                            model.push({
+                                id: 'authorizeCl',
+                                label: __('Authorize'),
+                                type: 'actions',
+                                actions: [
+                                    {
+                                        id: 'authorize',
+                                        icon: 'play',
+                                        title: __('Authorize session'),
+                                        disabled() {
+                                            return !canDo('authorize', this.state);
+                                        },
+                                        action: authorize
+                                    }
+                                ]
+                            });
+                        }
+
+                        if (data.canPause === null || data.canPause) {
+                            // action: pause the execution
+                            model.push({
+                                id: 'pauseCl',
+                                label: __('Pause'),
+                                type: 'actions',
+                                actions: [
+                                    {
+                                        id: 'pause',
+                                        icon: 'pause',
+                                        title: __('Pause session'),
+                                        disabled() {
+                                            return !canDo('pause', this.state);
+                                        },
+                                        action: pause
+                                    }
+                                ]
+                            });
+                        }
+
+                        // column: remaining time
+                        if (showColumnRemainingTime) {
+                            model.push({
+                                id: 'remaining_time',
+                                sortable: true,
+                                sorttype: 'numeric',
+                                label: __('Remaining'),
+                                transform(value, row) {
+                                    var rowTimer = _.isObject(row.timer) ? row.timer : {};
+                                    var refinedValue = rowTimer.approximatedRemaining
+                                        ? rowTimer.approximatedRemaining
+                                        : rowTimer.remaining_time;
+                                    var remaining = parseInt(refinedValue, 10);
+                                    if (remaining || _.isFinite(remaining)) {
+                                        if (remaining < 0) {
+                                            if (rowTimer.extraTime && rowTimer.consumedExtraTime) {
+                                                rowTimer.consumedExtraTime += -remaining;
+                                            }
+                                            remaining = 0;
+                                        }
+                                        if (remaining) {
+                                            if (rowTimer.extraTime && rowTimer.consumedExtraTime) {
+                                                remaining -= rowTimer.consumedExtraTime;
+                                            }
+                                            refinedValue = timeEncoder.encode(remaining);
+                                        } else {
+                                            refinedValue = '';
+                                        }
+
+                                        refinedValue = approximatedTimerTpl({
+                                            timer: refinedValue,
+                                            remaining: remaining,
+                                            countDown: rowTimer.countDown
+                                        });
+                                    }
+
+                                    return refinedValue;
+                                }
+                            });
+                        }
+                        if (timeHandlingMode) {
+                            model.push({
+                                id: 'extraTime',
+                                label: __('Extra Time'),
+                                type: 'actions',
+                                actions: [
+                                    {
+                                        id: 'timeHandling',
+                                        title: __('Session time handling'),
+                                        icon: 'time',
+                                        action: timeHandling,
+                                        hidden() {
+                                            var allowExtraTime = _.isNull(this.allowExtraTime) || this.allowExtraTime;
+                                            return !canDo('time', this.state) || !allowExtraTime;
+                                        }
+                                    }
+                                ]
+                            });
+                        }
+                        if (changeTimeMode) {
+                            model.push({
+                                id: 'adjustTime',
+                                label: __('Change time'),
+                                type: 'actions',
+                                actions: [
+                                    {
+                                        id: 'timeHandling',
+                                        title: __('Session time handling'),
+                                        icon: 'time',
+                                        action: timeAdjustment,
+                                        disabled() {
+                                            return !this.allowTimerAdjustment;
+                                        }
+                                    }
+                                ]
+                            });
+                        }
+                        if (showColumnExtendedTime) {
+                            model.push({
+                                id: 'extendedTime',
+                                label: __('Changed Time'),
+                                transform(value, row) {
+                                    const state = [];
+                                    const timer = _.isObject(row.timer) ? row.timer : {};
+                                    const { adjustedTime, extendedTime, extraTime } = timer;
+
+                                    if (extendedTime) {
+                                        state.push(`${__('Extended time')}: x${extendedTime}`);
+                                    }
+                                    if (extraTime) {
+                                        state.push(`${__('Extra')}: ${timeEncoder.encode(extraTime)}`);
+                                    }
+                                    if (adjustedTime) {
+                                        state.push(
+                                            `${__('Adjusted')}: ${adjustedTime > 0 ? '' : '-'}${timeEncoder.encode(
+                                                Math.abs(adjustedTime)
+                                            )}`
+                                        );
+                                    }
+                                    return state.join('<br />');
+                                }
+                            });
+                        }
+
+                        if (allowedConnectivity) {
+                            // column: connectivity status of execution progress
+                            model.push({
+                                id: 'last_connect',
+                                sortable: true,
+                                label: __('Connectivity'),
+                                transform(value, row) {
+                                    if (row.state.status === _status.STATUS_INPROGRESS) {
+                                        return row.online ? __('online') : __('offline');
+                                    }
+                                    return '';
+                                }
+                            });
+                        }
+
+                        // column: delivery execution progress
+                        model.push({
+                            id: 'progress',
+                            label: __('Progress'),
+                            transform(value, row) {
+                                return (row && row.state && row.state.progress) || '';
+                            }
+                        });
+
+                        label = __('Terminate');
+                        if (allowIrr) {
+                            label = __('Terminate and irregularity');
+                            if (hasAccessToReactivate) {
+                                label = __('Terminate/Reactivate and irregularity');
+                            }
+                        } else if (hasAccessToReactivate) {
+                            label = __('Terminate/Reactivate');
+                        }
+
+                        // column: proctoring actions
+                        actionList = [
+                            {
+                                id: 'terminateOrReactivateAndIrregularity',
+                                icon: 'delivery-small',
+                                title: label,
+                                disabled: true,
+                                action: terminateOrReactivateAndIrregularity
+                            }
+                        ];
+
+                        if (showActionShowHistory) {
+                            actionList.push({
+                                id: 'history',
+                                icon: 'history',
+                                title: __('Show the detailed session history'),
+                                action: showHistory
+                            });
+                        }
+
+                        if (printReportButton) {
+                            actionList.push({
+                                id: 'printReport',
+                                title: __('Print the assessment results'),
+                                icon: 'result',
+                                action: printReport
+                            });
+                        }
+
+                        model.push({
+                            id: 'administrationCl',
+                            label: __('Administration'),
+                            type: 'actions',
+                            actions: actionList
+                        });
+
+                        // renders the datatable
+                        $list
+                            .on('query.datatable', function (event, ajaxConfig) {
+                                loadingBar.start();
+                                highlightRows = [];
+                                startPollingData(data, ajaxConfig);
+                            })
+                            .on('beforeload.datatable', (e, dataSet) => {
+                                // We save response data here because on load the data will be transformed
+                                originalDataset = dataSet;
+                            })
+                            .on('load.datatable', function (e, newDataset) {
+                                var applyTags;
+
+                                //update dateset in memory
+                                dataset = newDataset;
+
+                                // activate irregularity buttons
+                                $('.terminateOrReactivateAndIrregularity', $list).each((ind, btn) => {
+                                    const $btn = $(btn);
+                                    const uri = $btn.closest('[data-item-identifier]').data('item-identifier');
+                                    const delivery = getExecutionData(uri);
+                                    if (
+                                        (hasAccessToReactivate && canDo('reactivate', delivery.state)) ||
+                                        canDo('terminate', delivery.state) ||
+                                        allowIrr
+                                    ) {
+                                        $btn.prop('disabled', false);
+                                    }
+                                });
+
+                                //update the buttons, which have been reconstructed
+                                actionButtons = _({
+                                    authorize: $list.find('.action-bar').children('.tool-authorise'),
+                                    pause: $list.find('.action-bar').children('.tool-pause'),
+                                    terminate: $list.find('.action-bar').children('.tool-terminate'),
+                                    report: $list.find('.action-bar').children('.tool-irregularity')
+                                });
+
+                                if (defaultTag) {
+                                    applyTags = $list.data('applytags');
+                                    applyTags = !_.isUndefined(applyTags) ? applyTags : true;
+                                    setTagUsage(applyTags);
+                                }
+
+                                // highlight rows
+                                if (highlightRows.length) {
+                                    _.forEach(highlightRows, function (v) {
+                                        $list.datatable('highlightRow', v);
                                     });
                                 }
+                                loadingBar.stop();
 
-                                return refinedValue;
-                            }
-                        });
-                    }
-                    if (timeHandlingMode) {
-                        model.push({
-                            id: 'extraTime',
-                            label: __('Extra Time'),
-                            type: 'actions',
-                            actions: [{
-                                id : 'timeHandling',
-                                title : __('Session time handling'),
-                                icon : 'time',
-                                action : timeHandling,
-                                hidden() {
-                                    var allowExtraTime = _.isNull(this.allowExtraTime) || this.allowExtraTime;
-                                    return !canDo('time', this.state) || !allowExtraTime;
-                                }
-                            }]
-                        });
-                    }
-                    if (changeTimeMode) {
-                        model.push({
-                            id: 'adjustTime',
-                            label: __('Change time'),
-                            type: 'actions',
-                            actions: [{
-                                id : 'timeHandling',
-                                title : __('Session time handling'),
-                                icon : 'time',
-                                action : timeAdjustment,
-                                disabled() {
-                                    return !this.allowTimerAdjustment;
-                                }
-                            }]
-                        });
-                    }
-                    if (showColumnExtendedTime) {
-                        model.push({
-                            id: 'extendedTime',
-                            label: __('Changed Time'),
-                            transform(value, row) {
-                                const state = [];
-                                const timer = _.isObject(row.timer) ? row.timer : {};
-                                const { adjustedTime, extendedTime, extraTime } = timer
-
-                                if (extendedTime) {
-                                    state.push(`${__('Extended time')}: x${extendedTime}`);
-                                }
-                                if (extraTime) {
-                                    state.push(`${__('Extra')}: ${timeEncoder.encode(extraTime)}`);
-                                }
-                                if (adjustedTime) {
-                                    state.push(`${__('Adjusted')}: ${adjustedTime > 0 ? '' : '-'}${timeEncoder.encode(Math.abs(adjustedTime))}`);
-                                }
-                                return state.join('<br />');
-                            }
-                        });
-                    }
-
-                    if (allowedConnectivity) {
-                        // column: connectivity status of execution progress
-                        model.push({
-                            id: 'last_connect',
-                            sortable: true,
-                            label: __('Connectivity'),
-                            transform(value, row) {
-                                if (row.state.status === _status.STATUS_INPROGRESS) {
-                                    return row.online ? __('online') : __('offline');
-                                }
-                                return '';
-                            }
-                        });
-                    }
-
-                    // column: delivery execution progress
-                    model.push({
-                        id: 'progress',
-                        label: __('Progress'),
-                        transform(value, row) {
-                            return row && row.state && row.state.progress || '' ;
-                        }
-                    });
-
-                    label = __('Terminate');
-                    if (allowIrr) {
-                        label = __('Terminate and irregularity');
-                        if (hasAccessToReactivate) {
-                            label = __('Terminate/Reactivate and irregularity');
-                        }
-                    } else if (hasAccessToReactivate) {
-                        label = __('Terminate/Reactivate');
-                    }
-
-                    // column: proctoring actions
-                    actionList = [{
-                        id: 'terminateOrReactivateAndIrregularity',
-                        icon: 'delivery-small',
-                        title: label,
-                        disabled: true,
-                        action: terminateOrReactivateAndIrregularity
-                    }];
-
-                    if (showActionShowHistory) {
-                        actionList.push({
-                            id: 'history',
-                            icon: 'history',
-                            title: __('Show the detailed session history'),
-                            action: showHistory
-                        });
-                    }
-
-                    if (printReportButton) {
-                        actionList.push({
-                            id : 'printReport',
-                            title : __('Print the assessment results'),
-                            icon : 'result',
-                            action : printReport
-                        });
-                    }
-
-                    model.push({
-                        id: 'administrationCl',
-                        label: __('Administration'),
-                        type: 'actions',
-                        actions: actionList
-                    });
-
-                    // renders the datatable
-                    $list
-                        .on('query.datatable', function() {
-                            loadingBar.start();
-                            highlightRows = [];
-                        })
-                        .on('load.datatable', function(e, newDataset) {
-                            var applyTags;
-
-                            //update dateset in memory
-                            dataset = newDataset;
-
-                            // activate irregularity buttons
-                            $('.terminateOrReactivateAndIrregularity', $list).each((ind, btn) => {
-                                const $btn = $(btn);
-                                const uri = $btn.closest('[data-item-identifier]').data('item-identifier');
-                                const delivery = getExecutionData(uri);
-                                if (
-                                  hasAccessToReactivate && canDo('reactivate', delivery.state)
-                                      || canDo('terminate', delivery.state)
-                                      || allowIrr
-                                ) {
-                                    $btn.prop('disabled', false);
-                                }
-                            });
-
-                            //update the buttons, which have been reconstructed
-                            actionButtons = _({
-                                authorize : $list.find('.action-bar').children('.tool-authorise'),
-                                pause : $list.find('.action-bar').children('.tool-pause'),
-                                terminate : $list.find('.action-bar').children('.tool-terminate'),
-                                report : $list.find('.action-bar').children('.tool-irregularity')
-                            });
-
-                            if (defaultTag) {
-                                applyTags = $list.data('applytags');
-                                applyTags = !_.isUndefined(applyTags) ? applyTags : true;
-                                setTagUsage(applyTags);
-                            }
-
-                            // highlight rows
-                            if (highlightRows.length) {
-                                _.forEach(highlightRows, function (v) {
-                                    $list.datatable('highlightRow', v);
-                                });
-                            }
-                            loadingBar.stop();
-
-                            appController
-                                .off('change.polling')
-                                .on('change.polling', function () {
+                                appController.off('change.polling').on('change.polling', function () {
                                     polling.stop();
                                 });
 
-                            polling.start();
-                            timer.resume();
-                        })
-                        .on('select.datatable', function() {
-                            //hide all controls then display each required one individually
-                            actionButtons.each(function($btn){
-                                $btn.hide();
-                            });
-                            _($list.datatable('selection')).map(function(uri){
-                                var row = getExecutionData(uri);
-                                return row.state.status;
-                            }).uniq().each(function(statusCode){
-                                var status = _status.getStatusByCode(statusCode);
-                                actionButtons.forIn(function($btn, action){
-                                    if(status && status.can[action] === true){
-                                        $btn.show();
-                                    }
+                                polling.start();
+                                timer.resume();
+                            })
+                            .on('select.datatable', function () {
+                                //hide all controls then display each required one individually
+                                actionButtons.each(function ($btn) {
+                                    $btn.hide();
                                 });
-                            });
-                        }).on('error.datatable', function(e, err){
-                            appController.onError(err);
-                        }).datatable({
-                            url: urlHelper.build(executionsUrl, serviceParams),
-                            status: {
-                                empty: __('No sessions'),
-                                available() {
-                                    return getTagsUsage() ? __("Groups: %s. %s", defaultTag.split(',').join(', '), defaultAvailableLabel) : defaultAvailableLabel;
+                                _($list.datatable('selection'))
+                                    .map(function (uri) {
+                                        var row = getExecutionData(uri);
+                                        return row.state.status;
+                                    })
+                                    .uniq()
+                                    .each(function (statusCode) {
+                                        var status = _status.getStatusByCode(statusCode);
+                                        actionButtons.forIn(function ($btn, action) {
+                                            if (status && status.can[action] === true) {
+                                                $btn.show();
+                                            }
+                                        });
+                                    });
+                            })
+                            .on('error.datatable', function (e, err) {
+                                stopPollingData();
+                                appController.onError(err);
+                            })
+                            .datatable(
+                                {
+                                    url: urlHelper.build(executionsUrl, serviceParams),
+                                    status: {
+                                        empty: __('No sessions'),
+                                        available() {
+                                            return getTagsUsage()
+                                                ? __(
+                                                      'Groups: %s. %s',
+                                                      defaultTag.split(',').join(', '),
+                                                      defaultAvailableLabel
+                                                  )
+                                                : defaultAvailableLabel;
+                                        },
+                                        loading: __('Loading')
+                                    },
+                                    filterStrategy: 'multiple',
+                                    filterSelector: 'select, input:not(.select2-input, .select2-focusser)',
+                                    filtercolumns: {
+                                        start_time: setStartDataOneDay ? getDefaultStartTimeFilter() : ''
+                                    },
+                                    filter: true,
+                                    tools: tools,
+                                    model: model,
+                                    selectable: true,
+                                    sortorder: 'desc',
+                                    sortby: 'start_time',
+                                    pageSizeSelector: true
                                 },
-                                loading: __('Loading')
-                            },
-                            filterStrategy: 'multiple',
-                            filterSelector: 'select, input:not(.select2-input, .select2-focusser)',
-                            filtercolumns: {start_time: (setStartDataOneDay ? getDefaultStartTimeFilter() : "")},
-                            filter: true,
-                            tools: tools,
-                            model: model,
-                            selectable: true,
-                            sortorder: 'desc',
-                            sortby : 'start_time',
-                            pageSizeSelector: true,
-                        }, dataset);
-
-                    setInitialFilters();
+                                dataset
+                            );
+                        setInitialFilters();
+                    });
+                })
+                .catch(function (err) {
+                    appController.onError(err);
+                    loadingBar.stop();
                 });
-            }).catch(function(err) {
-                appController.onError(err);
-                loadingBar.stop();
-            });
         }
     };
 });

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -759,9 +759,7 @@ define([
                                     try {
                                         const shouldRefreshDataTable = isReponseDataChanged(response, originalDataset);
 
-                                        console.log('shouldRefreshDataTable', shouldRefreshDataTable);
                                         if (shouldRefreshDataTable) {
-                                            console.log('refresh');
                                             $list.datatable('refresh', response);
                                         }
                                     } finally {

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -1355,7 +1355,6 @@ define([
                                     polling.stop();
                                 });
 
-                                console.log('Start timer');
                                 polling.start();
                                 timer.resume();
                             })

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -678,7 +678,7 @@ define([
                     }
 
                     /**
-                     * Additional action perfomed with filter element
+                     * Additional action performed with filter element
                      * @param {jQueryElement} $el
                      */
                     function statusFilterHandler($el) {
@@ -708,7 +708,7 @@ define([
                      * @param {*} response
                      * @param {*} savedResponse
                      */
-                    function isReponseDataChanged(response, savedResponse) {
+                    function isResponseDataChanged(response, savedResponse) {
                         if (_.has(response, 'data') && _.has(savedResponse, 'data')) {
                             const newData = response.data;
                             const savedData = savedResponse.data;
@@ -743,21 +743,21 @@ define([
                     }
 
                     function startPollingData(data, ajaxConfig) {
-                        const isPollingAvaible = data.autoRefresh && ajaxConfig;
+                        const isPollingAvailable = data.autoRefresh && ajaxConfig;
 
                         stopPollingData();
 
-                        if (!isPollingAvaible) {
+                        if (!isPollingAvailable) {
                             return;
                         }
 
-                        dataPolling.setAction(function (proccess) {
-                            const action = proccess.async();
+                        dataPolling.setAction(function (process) {
+                            const action = process.async();
 
                             $.ajax(ajaxConfig)
                                 .then(response => {
                                     try {
-                                        const shouldRefreshDataTable = isReponseDataChanged(response, originalDataset);
+                                        const shouldRefreshDataTable = isResponseDataChanged(response, originalDataset);
 
                                         if (shouldRefreshDataTable) {
                                             $list.datatable('refresh', response);


### PR DESCRIPTION
**Related to task:**  https://oat-sa.atlassian.net/browse/NCC-222
**Description:** The polling data process for proctoring page is activated by setting time (ms) for `autoRefresh` field in the `config/taoProctoring/GuiSettings.conf.php`.
The data in table will be refreshed only if data are different with data in a previous response. We check delivery execution id and state status

**How to test:** 
- Set in `config/taoProctoring/GuiSettings.conf.php` interval for polling
```
'autoRefresh' => 3000,
```
- Login with proctor rights and navigate to the proctoring page
- Open new session and login as test taker
- As TT change the QTI test state by starting/pause QTI test. The data on the proctoring page should be reloaded in given poll interval

**Unit tests cli:** npx grunt testall