### PR TITLE
Fix/tca 600/avoid system pause reason prepopulation

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.18.0',
+    'version' => '19.18.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=41.9.1',

--- a/model/execution/DeliveryExecutionList.php
+++ b/model/execution/DeliveryExecutionList.php
@@ -159,6 +159,15 @@ class DeliveryExecutionList extends ConfigurableService
         return $execution;
     }
 
+    private function isPausedByProctor($lastPause): bool
+    {
+        return isset(
+            $lastPause[0][DeliveryLog::DATA]['reason'],
+            $lastPause[0][DeliveryLog::DATA]['context']
+        )
+        && $lastPause[0][DeliveryLog::DATA]['context'] === '/taoProctoring/Monitor/pauseExecutions';
+    }
+
     private function getLastProctorPauseReason(string $deliveryExecutionId): ?array
     {
         $reason = null;
@@ -171,13 +180,7 @@ class DeliveryExecutionList extends ConfigurableService
             'limit' => 1,
         ]);
 
-        if (
-            isset(
-                $lastPause[0][DeliveryLog::DATA]['reason'],
-                $lastPause[0][DeliveryLog::DATA]['context']
-            )
-            && $lastPause[0][DeliveryLog::DATA]['context'] === '/taoProctoring/Monitor/pauseExecutions'
-        ) {
+        if ($this->isPausedByProctor($lastPause)) {
             $reason = $lastPause[0][DeliveryLog::DATA]['reason'];
         }
 

--- a/model/execution/DeliveryExecutionList.php
+++ b/model/execution/DeliveryExecutionList.php
@@ -94,9 +94,7 @@ class DeliveryExecutionList extends ConfigurableService
      * @return array
      * @throws common_Exception
      * @throws common_exception_Error
-     * @throws common_exception_NotFound
      * @throws common_ext_ExtensionException
-     * @throws InvalidServiceManagerException
      * @throws QtiTestExtractionFailedException
      */
     private function createExecution($cachedData, $extraFields): array
@@ -143,7 +141,7 @@ class DeliveryExecutionList extends ConfigurableService
         }
 
         if ($isTimerAdjustmentAllowed) {
-            $reason = $this->getLastPauseReason($cachedData[DeliveryMonitoringService::DELIVERY_EXECUTION_ID]);
+            $reason = $this->getLastProctorPauseReason($cachedData[DeliveryMonitoringService::DELIVERY_EXECUTION_ID]);
             if ($reason) {
                 $execution['lastPauseReason'] = $reason;
             }
@@ -161,7 +159,7 @@ class DeliveryExecutionList extends ConfigurableService
         return $execution;
     }
 
-    private function getLastPauseReason(string $deliveryExecutionId): ?array
+    private function getLastProctorPauseReason(string $deliveryExecutionId): ?array
     {
         $reason = null;
         $lastPause = $this->getDeliveryLogService()->search([
@@ -173,7 +171,13 @@ class DeliveryExecutionList extends ConfigurableService
             'limit' => 1,
         ]);
 
-        if (isset($lastPause[0][DeliveryLog::DATA]['reason'])) {
+        if (
+            isset(
+                $lastPause[0][DeliveryLog::DATA]['reason'],
+                $lastPause[0][DeliveryLog::DATA]['context']
+            )
+            && $lastPause[0][DeliveryLog::DATA]['context'] === '/taoProctoring/Monitor/pauseExecutions'
+        ) {
             $reason = $lastPause[0][DeliveryLog::DATA]['reason'];
         }
 

--- a/model/execution/DeliveryExecutionList.php
+++ b/model/execution/DeliveryExecutionList.php
@@ -162,7 +162,7 @@ class DeliveryExecutionList extends ConfigurableService
 
     private function isPausedByProctor($lastPause): bool
     {
-        $url = '/'.tao_helpers_Uri::getPath(
+        $url = tao_helpers_Uri::getPath(
             _url('pauseExecutions', 'Monitor', 'taoProctoring')
         );
         return isset(

--- a/model/execution/DeliveryExecutionList.php
+++ b/model/execution/DeliveryExecutionList.php
@@ -36,6 +36,7 @@ use oat\taoProctoring\model\monitorCache\DeliveryMonitoringService;
 use oat\taoProctoring\model\TestSessionConnectivityStatusService;
 use oat\taoQtiTest\models\QtiTestExtractionFailedException;
 use oat\taoQtiTest\models\SessionStateService;
+use tao_helpers_Uri;
 
 /**
  * Class DeliveryHelperService
@@ -161,11 +162,14 @@ class DeliveryExecutionList extends ConfigurableService
 
     private function isPausedByProctor($lastPause): bool
     {
+        $url = '/'.tao_helpers_Uri::getPath(
+            _url('pauseExecutions', 'Monitor', 'taoProctoring')
+        );
         return isset(
             $lastPause[0][DeliveryLog::DATA]['reason'],
             $lastPause[0][DeliveryLog::DATA]['context']
         )
-        && $lastPause[0][DeliveryLog::DATA]['context'] === '/taoProctoring/Monitor/pauseExecutions';
+        && mb_strpos($lastPause[0][DeliveryLog::DATA]['context'], $url) !== false;
     }
 
     private function getLastProctorPauseReason(string $deliveryExecutionId): ?array

--- a/test/unit/model/execution/DeliveryExecutionListTest.php
+++ b/test/unit/model/execution/DeliveryExecutionListTest.php
@@ -292,6 +292,7 @@ class DeliveryExecutionListTest extends TestCase
             [
                 DeliveryLog::DATA => [
                     'reason' => ['reason'],
+                    'context' => '/taoProctoring/Monitor/pauseExecutions'
                 ]
             ]
         ]);


### PR DESCRIPTION
Pull request summary
 
Related to : https://oat-sa.atlassian.net/browse/TCA-600
 
The pre-population shall only occur if it c"n be "etermined t"at the"proctor almost certainly clicked on “Pause” (i.e. the “paused” session of the TT has been initiated by the Proctor and NOT by the TT losing focus)

How to test:

1. In the DE with secure mode press ESC and there will be an pause action, check that proctor doesn't see reasons when clicks on the adjustment time button
2. When proctor pauses DE by himself - then pre-populated data should be filled for the adjustment time action