### PR TITLE
Fix/tca 707/dialog on terminated session

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.18.2',
+    'version' => '19.18.3',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=41.9.1',

--- a/views/js/controller/DeliveryServer/awaiting.js
+++ b/views/js/controller/DeliveryServer/awaiting.js
@@ -81,7 +81,7 @@ define([
                         if (result.message) {
                             dialogAlert(result.message, exit);
                         } else {
-                            exit();
+                            dialogAlert(__('Unexpected response'), exit);
                         }
                     } else if (result.authorized) {
                         clipboard.clean();
@@ -177,7 +177,7 @@ define([
                             if (result.message) {
                                 dialogAlert(result.message, exit);
                             } else {
-                                exit();
+                                dialogAlert(__('Unexpected response'), exit);
                             }
                         } else if (result.authorized) {
                             stop = true;

--- a/views/js/controller/DeliveryServer/awaiting.js
+++ b/views/js/controller/DeliveryServer/awaiting.js
@@ -74,9 +74,23 @@ define([
 
             const runDelivery = () => {
                 loadingBar.start();
-                clipboard.clean();
-                deliveryStarted = true;
-                window.location.href = runDeliveryUrl;
+
+                // make sure that the delivery is still allowed (before redirect)
+                $.get(isAuthorizedUrl, (result) => {
+                    if (!result.success) {
+                        if (result.message) {
+                            dialogAlert(result.message, exit);
+                        } else {
+                            exit();
+                        }
+                    } else if (result.authorized) {
+                        clipboard.clean();
+                        deliveryStarted = true;
+                        window.location.href = runDeliveryUrl;
+                    } else {
+                        dialogAlert(__('Unexpected response'), exit);
+                    }
+                });
             };
 
             const isRunnable = () => {


### PR DESCRIPTION
Pull request summary
 
Related to: https://oat-sa.atlassian.net/browse/TCA-707
 
#### Steps to reproduce  (for bugs)
 - Launch a test as test-taker.
 - Authorize the test as proctor.
 - On 'awaiting authorization' screen, make sure that proceed button is enabled.
 - Terminate the test as proctor.
 - Notice that there is no termination message presented to the test taker.
 - Test taker can click on 'Proceed' and is taken to a blank page that has "My tests"  heading.
  
#### How to test
 
- Test taker is on awaiting authorization page (with Proceed button enabled) and proctor terminates the test
- When TT clicks on Proceed the system performs a last check and to displays a warning dialog to inform clearly on the issue  (notify about the test termination). 
- Then, only after the TT acknowledged what happened and click on “ok”, the TT is redirected to the index page.