### PR TITLE
Fix/NCC-243/Restore code for auto refresh

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.18.2',
+    'version' => '19.19.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=41.9.1',

--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.19.0',
+    'version' => '19.18.3',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=41.9.1',

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -78,8 +78,6 @@ define([
     approximatedTimerTpl
 ) {
     'use strict';
-
-    debugger;
     /**
      * The CSS scope
      * @type {String}

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -79,6 +79,7 @@ define([
 ) {
     'use strict';
 
+    debugger;
     /**
      * The CSS scope
      * @type {String}
@@ -140,6 +141,7 @@ define([
             var dataset;
             var extraFields;
             var categories;
+            var originalDataset;
             let timeHandlingMode;
             let changeTimeMode;
             var allowedConnectivity;
@@ -176,6 +178,12 @@ define([
                 interval: 1000,
                 autoStart: false
             });
+
+            const dataPolling = pollingFactory({
+                interval: 2000,
+                autoStart: false
+            });
+
             appController.on('change.deliveryMonitoring', function() {
                 appController.off('.deliveryMonitoring');
                 container.destroy();
@@ -681,6 +689,73 @@ define([
                     return _.isUndefined(object[option], undefined) ? defaultValue : object[option];
                 }
 
+                /**
+                * Compare responses data
+                * @param {Object} response
+                * @param {Object} savedResponse
+                */
+                function isResponseDataChanged(response, savedResponse) {
+                    if (_.has(response, 'data') && _.has(savedResponse, 'data')) {
+                        const newData = response.data;
+                        const savedData = savedResponse.data;
+
+                        if (_.isArray(newData) && _.isArray(savedData)) {
+                            let newDataSize = _.size(newData);
+                            let savedDataSize = _.size(savedData);
+
+                            if (newDataSize !== savedDataSize) {
+                                return true;
+                            }
+
+                            while (newDataSize--) {
+                                const newDeliveryId = newData[newDataSize].id;
+                                const newDeliveryStatus = newData[newDataSize].state.status;
+                                const savedDeliveryId = savedData[newDataSize].id;
+                                const savedDeliveryStatus = savedData[newDataSize].state.status;
+
+                                const isDeliveriesEqual = _.isEqual(newDeliveryId, savedDeliveryId) && _.isEqual(newDeliveryStatus, savedDeliveryStatus);
+
+                                if (!isDeliveriesEqual) {
+                                    return true;
+                                }
+                            }
+                            
+                            return false;
+                        }
+                    }
+
+                    return _.isEqual(response, savedResponse);
+                }
+
+                function startPollingData(pollingInterval, ajaxConfig) {
+                    stopPollingData();
+
+                    dataPolling.setAction(function (process) {
+                        const action = process.async();
+
+                        $.ajax(ajaxConfig)
+                            .then(response => {
+                                try {
+                                    const shouldRefreshDataTable = isResponseDataChanged(response, originalDataset);
+
+                                    if (shouldRefreshDataTable) {
+                                       $list.datatable('refresh', response);
+                                    }
+                                } finally {
+                                   action.resolve();
+                                }
+                            })
+                            .fail(action.resolve);
+                        });
+
+                    dataPolling.setInterval(pollingInterval);
+                    dataPolling.start();
+                }
+
+                function stopPollingData() {
+                    dataPolling.stop();
+                }
+
                 if (deliveryId) {
                     serviceParams.delivery = deliveryId;
                 }
@@ -732,15 +807,6 @@ define([
                                 $list.datatable('refresh');
                             }
                         });
-                    }
-
-                    /**
-                     * Configurable parameter to auto renew datatable
-                     */
-                    if (data.autoRefresh) {
-                        setInterval(function () {
-                            $list.datatable('refresh');
-                        }, data.autoRefresh);
                     }
 
                     if (defaultTag) {
@@ -1194,9 +1260,19 @@ define([
 
                     // renders the datatable
                     $list
-                        .on('query.datatable', function() {
+                        .on('query.datatable', function(event, ajaxConfig) {
                             loadingBar.start();
                             highlightRows = [];
+
+                            const isPollingAvailable = data.autoRefresh && ajaxConfig;
+
+                            if (isPollingAvailable) {
+                                startPollingData(data.autoRefresh, ajaxConfig);
+                            }
+                        })
+                        .on('beforeload.datatable', (e, dataSet) => {
+                            // We save response data here because on load the data will be transformed
+                            originalDataset = dataSet;
                         })
                         .on('load.datatable', function(e, newDataset) {
                             var applyTags;


### PR DESCRIPTION
**Related to task:**  https://oat-sa.atlassian.net/browse/NCC-243
https://oat-sa.atlassian.net/browse/NCC-222
**Explanation:** [The code for auto refresh](https://github.com/oat-sa/extension-tao-proctoring/pull/830) were accidentally  removed. The changes are restored by this pull request.

**Description:** On proctor page `autoRefresh` option activate polling data from server. The value of `autoRefresh` is time in milliseconds between sending get requests.
The data in proctor table will be refreshed only if data are different with data in a previous response. We compare only delivery execution id order and delivery state status.

**How to test:** 
- Set in `config/taoProctoring/GuiSettings.conf.php` interval for polling
```
'autoRefresh' => 3000,
```
- Login with proctor rights and navigate to the proctoring page
- Open a new session and login as test taker
- As TT change the QTI test state by starting/pause/... QTI test. The data in the proctoring table will be updated in given `autoRefresh` interval without additional click on a "Refresh" button.

**Unit tests cli:** npx grunt testall