### PR TITLE
Fix/ncc 239/title webpage on browser from test label

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.18.2',
+    'version' => '19.18.3',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=41.9.1',

--- a/model/execution/DeliveryExecutionManagerService.php
+++ b/model/execution/DeliveryExecutionManagerService.php
@@ -28,6 +28,7 @@ use common_exception_MissingParameter;
 use common_exception_NotFound;
 use common_ext_ExtensionException;
 use common_session_Session;
+use core_kernel_classes_Resource;
 use Exception;
 use oat\oatbox\event\EventManager;
 use oat\oatbox\service\ConfigurableService;
@@ -453,6 +454,15 @@ class DeliveryExecutionManagerService extends ConfigurableService
         }
 
         return $adjustedTime;
+    }
+
+    /**
+     * @param core_kernel_classes_Resource $delivery
+     * @return string
+     */
+    public function getTitle(core_kernel_classes_Resource $delivery)
+    {
+        return __('TAO: %s', $delivery->getLabel());
     }
 
     /**

--- a/model/execution/DeliveryExecutionManagerService.php
+++ b/model/execution/DeliveryExecutionManagerService.php
@@ -457,6 +457,8 @@ class DeliveryExecutionManagerService extends ConfigurableService
     }
 
     /**
+     * get Title of the Webpage on the Browser Tab
+     *
      * @param core_kernel_classes_Resource $delivery
      * @return string
      */


### PR DESCRIPTION
__Related to task:__ https://oat-sa.atlassian.net/browse/NCC-239
__Description:__ Title of the Webpage on the Browser Tab Pulls from Test Label

__How to test:__
Launch test as a test taker by clicking start
Authorize from proctor screen in separate browser
Click proceed
Click agree on the security statement
Start test

__It depends on it__: https://github.com/oat-sa/extension-tao-delivery/pull/489 