### PR TITLE
Fix/tca 573/allow time adjustment only for deliveries with timer

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.18.3',
+    'version' => '19.18.4',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=41.9.1',

--- a/model/execution/DeliveryExecutionManagerService.php
+++ b/model/execution/DeliveryExecutionManagerService.php
@@ -395,7 +395,13 @@ class DeliveryExecutionManagerService extends ConfigurableService
             return false;
         }
 
-        if (!$this->getTestSessionService()->getTestSession($deliveryExecution)) {
+        $testSession = $this->getTestSessionService()->getTestSession($deliveryExecution);
+        if (!$testSession instanceof TestSession) {
+            return false;
+        }
+
+        $timeConstraint = $this->getTestSessionService()->getSmallestMaxTimeConstraint($testSession);
+        if ($timeConstraint === null) {
             return false;
         }
 


### PR DESCRIPTION
JIRA ticket: https://oat-sa.atlassian.net/browse/TCA-573

Problem:
- timer adjustment is allowed for delivery executions without timer.

How to test:
- create and start two delivery executions, one with timer and one without
- authorize -> start -> pause both delivery executions
- check on proctor screen that time adjustment button is active only for delivery execution with timer (only "Delivery of SAMPLEMATH_B1 test" on the screen has a timer).
<img width="1432" alt="Screenshot 2020-07-16 at 16 24 52" src="https://user-images.githubusercontent.com/42937157/87683087-ecc07a80-c780-11ea-8147-9799139e224b.png">
