### PR TITLE
Fix/tca 725/update test position and remaining time on reactivation

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.18.4',
+    'version' => '19.18.5',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=41.9.1',


### PR DESCRIPTION
JIRA ticket: https://oat-sa.atlassian.net/browse/TCA-725

Problem: when terminated test session is reactivated it shows incorrect test position `finished - item /` and empty remaining time.

Solution: test session reactivation triggers event `QtiTestStateChangeEvent`. Update test position and remaining time in delivery monitoring to represent real test session state.

How to test:
- start delivery execution 
- terminate delivery execution
- reactivate delivery execution (requires both `TeachingAssistant` and `Administrator` roles for proctor user)
- check that on proctor screen there are correct data in `Progress` and `Remaining` columns