### PR TITLE
Feature/tca 769/extra field not populated

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.19.1',
+    'version' => '19.20.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=45.6.3',


### PR DESCRIPTION
Only pull all monitoring data for proctor screen when necessary.
 
Related to : https://oat-sa.atlassian.net/browse/TCA-769
 
All monitoring data is pulled only when there are extra fields configured and they are not present in main `delivery_monitoring` table.
  
#### How to test
 

- Set up `taoProctoring:monitoringUserExtraFields` configuration option with some extra fields, f.e. `LtiListenerService::LTI_USER_NAME`
- Verify that the configured field is displayed correctly in proctor screen when it it stored in `kv_delivery_monitoring` table and also when migrated to `delivery_monitoring` table.

  
#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/extension-lti-proctoring/pull/144