### PR TITLE
Fix/BSA-269/Extra Time limit error message

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.19.1',
+    'version' => '19.19.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=45.6.3',

--- a/views/js/component/timeHandling/timeHandling.js
+++ b/views/js/component/timeHandling/timeHandling.js
@@ -146,7 +146,9 @@ define([
                             const remainingTime = Math.floor(resource.remaining_time) || 0;
                             const limitTime = Math.floor(resource.timeAdjustmentLimits.decrease + resource.timeAdjustmentLimits.increase) || 0;
 
-                            const tooMuch = (changeTimeOperator === '') && (resource.timeAdjustmentLimits.increase < timeUnit*value) ;
+                            const tooMuch = (changeTimeOperator === '')
+                                && (resource.timeAdjustmentLimits.increase !== -1)
+                                && (resource.timeAdjustmentLimits.increase < timeUnit*value);
                             const tooFew = (changeTimeOperator === '-') && (timeUnit*value > resource.remaining_time);
 
                             resError = error || tooMuch || tooFew;


### PR DESCRIPTION
Relates to: [BSA-269](https://oat-sa.atlassian.net/browse/BSA-269)

**Changes:** do not show error if time adjustment increase limit setted to -1.

**How to test:**
1. create the delivery with timed section(s);
2. execute the delivery via TT and pause it via Proctor;
3. refresh the page via Proctor and add Extra Time value which will be greater than consumed time (e.g. if timer was setted to 10 minutes and it was paused on 9:00 - consumed time is 1 minute. So you need to add Extra Time more than 1 minute).

_Previous behaviour: **error message.**_
_Current behaviour: **no error message, extra time has no limits.**_

**Companion PR:** [#74](https://github.com/oat-sa/extension-tao-bosa-selor/pull/74)