### PR TITLE
Feature/pr 28/update remaining time on proctor pause

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.19.2',
+    'version' => '19.20.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=45.6.3',

--- a/migrations/Version202011121023284101_taoProctoring.php
+++ b/migrations/Version202011121023284101_taoProctoring.php
@@ -1,5 +1,23 @@
 <?php
 
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+
 declare(strict_types=1);
 
 namespace oat\taoProctoring\migrations;

--- a/migrations/Version202011121023284101_taoProctoring.php
+++ b/migrations/Version202011121023284101_taoProctoring.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoProctoring\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\oatbox\event\EventManager;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState;
+use oat\taoProctoring\model\listener\DeliveryExecutionStateListener;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version202011121023284101_taoProctoring extends AbstractMigration
+{
+
+    public function getDescription(): string
+    {
+        return 'Register event handlers to update state in delivery monitoring when test session status changes.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        /** @var EventManager $eventManager */
+        $eventManager = $this->getServiceLocator()->get(EventManager::SERVICE_ID);
+        $eventManager->attach(
+            DeliveryExecutionState::class,
+            [
+                DeliveryExecutionStateListener::class,
+                'updateRemainingTime'
+            ]
+        );
+
+        $this->getServiceLocator()->register(EventManager::SERVICE_ID , $eventManager);
+    }
+
+    public function down(Schema $schema): void
+    {
+        /** @var EventManager $eventManager */
+        $eventManager = $this->getServiceLocator()->get(EventManager::SERVICE_ID);
+        $eventManager->detach(
+            DeliveryExecutionState::class,
+            [
+                DeliveryExecutionStateListener::class,
+                'updateRemainingTime'
+            ]
+        );
+
+        $this->getServiceLocator()->register(EventManager::SERVICE_ID , $eventManager);
+    }
+}

--- a/model/listener/DeliveryExecutionStateListener.php
+++ b/model/listener/DeliveryExecutionStateListener.php
@@ -31,6 +31,15 @@ use oat\taoTests\models\runner\time\TimePoint;
 
 class DeliveryExecutionStateListener extends ConfigurableService
 {
+    /**
+     * When test session is paused by proctor remaining time is recalculated based on server timer to show
+     * more precise value. After receiving pause confirmation from client remaining time will be recalculated
+     * to show correct value.
+     *
+     * @param DeliveryExecutionState $event
+     * @throws \common_Exception
+     * @throws \common_exception_NotFound
+     */
     public function updateRemainingTime(DeliveryExecutionState $event): void
     {
         if ($event->getState() != DeliveryExecution::STATE_PAUSED) {

--- a/model/listener/DeliveryExecutionStateListener.php
+++ b/model/listener/DeliveryExecutionStateListener.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+declare(strict_types=1);
+
+namespace oat\taoProctoring\model\listener;
+
+use oat\oatbox\service\ConfigurableService;
+use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState;
+use oat\taoProctoring\model\execution\DeliveryExecution;
+use oat\taoProctoring\model\monitorCache\DeliveryMonitoringService;
+use oat\taoQtiTest\models\runner\session\TestSession;
+use oat\taoQtiTest\models\TestSessionService;
+use oat\taoTests\models\runner\time\TimePoint;
+
+class DeliveryExecutionStateListener extends ConfigurableService
+{
+    public function updateRemainingTime(DeliveryExecutionState $event): void
+    {
+        if ($event->getState() != DeliveryExecution::STATE_PAUSED) {
+            return;
+        }
+        $deliveryExecution = $event->getDeliveryExecution();
+        $executionId = $deliveryExecution->getIdentifier();
+
+        $monitoringService = $this->getMonitoringService();
+        $data = $monitoringService->getData($deliveryExecution);
+        $testSession = $this->getTestSession($deliveryExecution);
+        if (empty($testSession)) {
+            $this->logWarning(
+                'monitor cache for delivery ' . $executionId . ' could not be updated. Test session could not be retrieved'
+            );
+            return;
+        }
+        $testSession->setTimerTarget(TimePoint::TARGET_SERVER);
+        $data->setTestSession($testSession);
+        $data->updateData([DeliveryMonitoringService::REMAINING_TIME]);
+
+        $success = $monitoringService->save($data);
+        if (!$success) {
+            $this->logWarning(
+                'monitor cache for delivery ' . $executionId . ' could not be updated. Remaining time was not updated'
+            );
+        }
+    }
+
+    /**
+     * @param $deliveryExecution
+     * @return null|TestSession
+     * @throws \common_Exception
+     */
+    private function getTestSession($deliveryExecution): ?TestSession
+    {
+        /** @var TestSessionService $testSessionService */
+        $testSessionService = $this->getServiceLocator()->get(TestSessionService::SERVICE_ID);
+
+        return $testSessionService->getTestSession($deliveryExecution, true);
+    }
+
+    /**
+     * @return DeliveryMonitoringService
+     */
+    private function getMonitoringService(): DeliveryMonitoringService
+    {
+        return $this->getServiceLocator()->get(DeliveryMonitoringService::SERVICE_ID);
+    }
+}

--- a/model/listener/DeliveryExecutionStateListener.php
+++ b/model/listener/DeliveryExecutionStateListener.php
@@ -63,8 +63,8 @@ class DeliveryExecutionStateListener extends ConfigurableService
 
         $success = $monitoringService->save($data);
         if (!$success) {
-            $this->logWarning(
-                'monitor cache for delivery ' . $executionId . ' could not be updated. Remaining time was not updated'
+            $this->logError(
+                'Monitor cache for delivery ' . $executionId . ' could not be updated. Remaining time was not updated'
             );
         }
     }

--- a/test/unit/model/listener/DeliveryExecutionStateListenerTest.php
+++ b/test/unit/model/listener/DeliveryExecutionStateListenerTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+declare(strict_types=1);
+
+namespace oat\taoProctoring\test\unit\model\listener;
+
+use oat\generis\test\MockObject;
+use oat\generis\test\TestCase;
+use oat\taoDelivery\model\execution\DeliveryExecution;
+use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
+use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState;
+use oat\taoProctoring\model\listener\DeliveryExecutionStateListener;
+use oat\taoProctoring\model\monitorCache\DeliveryMonitoringData;
+use oat\taoProctoring\model\monitorCache\DeliveryMonitoringService;
+use oat\taoQtiTest\models\runner\session\TestSession;
+use oat\taoQtiTest\models\TestSessionService;
+
+class DeliveryExecutionStateListenerTest extends TestCase
+{
+    /**
+     * @var DeliveryExecutionStateListener
+     */
+    private $subject;
+
+    /**
+     * @var TestSessionService|MockObject
+     */
+    private $testSessionServiceMock;
+
+    /** @var DeliveryMonitoringService|MockObject */
+    private $deliveryMonitoringServiceMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->testSessionServiceMock = $this->createMock(TestSessionService::class);
+        $this->testSessionServiceMock
+            ->method('getTestSession')
+            ->willReturn($this->createMock(TestSession::class));
+
+        $this->deliveryMonitoringServiceMock = $this->createMock(DeliveryMonitoringService::class);
+        $this->deliveryMonitoringServiceMock
+            ->method('getData')
+            ->willReturn($this->createMock(DeliveryMonitoringData::class));
+
+        $this->subject = new DeliveryExecutionStateListener();
+        $this->subject->setServiceLocator(
+            $this->getServiceLocatorMock(
+                [
+                    DeliveryMonitoringService::SERVICE_ID => $this->deliveryMonitoringServiceMock,
+                    TestSessionService::SERVICE_ID => $this->testSessionServiceMock
+                ]
+            )
+        );
+    }
+
+    public function testUpdateRemainingTime_WhenNewDeliveryExecutionStateIsPaused_ThenRemainingTimeIsRecalculated()
+    {
+        $this->deliveryMonitoringServiceMock
+            ->expects(self::once())
+            ->method('save')
+            ->willReturn(true);
+        $this->subject->updateRemainingTime(
+            new DeliveryExecutionState(
+                $this->createMock(DeliveryExecution::class),
+                DeliveryExecutionInterface::STATE_PAUSED,
+                DeliveryExecutionInterface::STATE_ACTIVE
+            )
+        );
+    }
+
+    public function testUpdateRemainingTime_WhenNewDeliveryExecutionStateIsNotPaused_ThenNoActionsTaken()
+    {
+        $this->deliveryMonitoringServiceMock
+            ->expects(self::never())
+            ->method('save');
+        $this->subject->updateRemainingTime(
+            new DeliveryExecutionState(
+                $this->createMock(DeliveryExecution::class),
+                DeliveryExecutionInterface::STATE_FINISHED,
+                DeliveryExecutionInterface::STATE_ACTIVE
+            )
+        );
+    }
+}
+


### PR DESCRIPTION
JIRA ticket: https://oat-sa.atlassian.net/browse/PR-28

Problem:
When proctor pauses a delivery execution remaining time shows value calculated based on last information from client test runner. It may cause some confusion when remaining time values becomes bigger, in some cases might be few minutes difference. 
To improve proctor user experience we can recalculate remaining time based on server timer. Later, when client test runner confirms pause event, remaining time will be recalculated based on test session timer and will contain the same remaining time as in test session.

How to test:
- (TT) start proctored delivery execution
- (proctor) authorize delivery execution
- (TT) wait for some time (at least 20-30 seconds)
- (proctor) pause delivery execution
- (TT) wait for next message request (is messages communication enabled) or try to move to the next item and confirm pause popup 
- (proctor) refresh the proctor screen, remaining time should contain the same value which was in client test runner when delivery execution was paused

Requires:
- [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1940