### PR TITLE
Fix/pr 89/hide extra time button when unrequired

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.20.0',
+    'version' => '19.20.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=45.6.3',

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -716,6 +716,18 @@ define([
                     serviceParams.context = context;
                 }
 
+                /**
+                 * Checks if button to add extra time must be available or not for a given ttSession checking
+                 * session configuration and status
+                 * @param {Object} ttSession - proctoring tts session
+                 */
+                function getAllowExtraTime(ttSession) {
+                    const sessionAllowsExtraTime = _.isNull(ttSession.allowExtraTime) || ttSession.allowExtraTime;
+                    const sessionStatusAllowsExtraTime = (ttSession.status !== 'Completed' && ttSession.status !== 'Terminated' && ttSession.timer.remaining_time !== 0);
+                    
+                    return sessionAllowsExtraTime && sessionStatusAllowsExtraTime;
+                }
+
                 return proxyExecutions.read(serviceParams).then(function(data) {
                     dataset = data.set;
                     extraFields = data.extrafields;
@@ -1098,7 +1110,7 @@ define([
                                 icon : 'time',
                                 action : timeHandling,
                                 hidden() {
-                                    var allowExtraTime = _.isNull(this.allowExtraTime) || this.allowExtraTime;
+                                    const allowExtraTime = getAllowExtraTime(this);
                                     return !canDo('time', this.state) || !allowExtraTime;
                                 }
                             }]

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -482,9 +482,9 @@ define([
                 function canDo(what, delivery) {
                     if (delivery && delivery.state.status) {
                         const status = _status.getStatusByCode(delivery.state.status);
-                        const canDo = _.isFunction(status.can[what]) ?status.can[what](delivery) : status.can[what];
+                        const isAllowed = _.isFunction(status.can[what]) ?status.can[what](delivery) : status.can[what];
 
-                        return status && canDo === true;
+                        return status && isAllowed === true;
                     }
                     return false;
                 }

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -325,8 +325,8 @@ define([
                 }
 
                 function terminateOrReactivateAndIrregularity(selection) {
-                    var delivery = getExecutionData(selection);
-                    var buttons = [];
+                    const delivery = getExecutionData(selection);
+                    const buttons = [];
                     if (hasAccessToReactivate && canDo('reactivate', delivery)) {
                         buttons.push({
                             id: 'reactivate',

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -480,7 +480,7 @@ define([
                  * @returns {Boolean}
                  */
                 function canDo(what, delivery) {
-                    if (delivery && delivery.state.status) {
+                    if (delivery && delivery.state && delivery.state.status) {
                         const status = _status.getStatusByCode(delivery.state.status);
                         const isAllowed = _.isFunction(status.can[what]) ?status.can[what](delivery) : status.can[what];
 

--- a/views/js/helper/status.js
+++ b/views/js/helper/status.js
@@ -37,7 +37,9 @@ define(['lodash', 'i18n'], function(_, __){
                 report : true,
                 print : __('not finished'),
                 reactivate : __('not terminated'),
-                time : true,
+                time : function(delivery) {
+                    return delivery.timer.remaining_time > 0;
+                },
                 changeTime: __('in progress'),
             },
             warning : {
@@ -236,7 +238,7 @@ define(['lodash', 'i18n'], function(_, __){
                 reactivate : __('not terminated'),
                 report : true,
                 print: true,
-                time : true,
+                time : false,
                 changeTime: __('completed'),
             },
             warning : {
@@ -341,7 +343,7 @@ define(['lodash', 'i18n'], function(_, __){
                 report : true,
                 reactivate : true,
                 print: true,
-                time : true,
+                time : false,
                 changeTime: __('terminated'),
             },
             warning : {


### PR DESCRIPTION
**Related to:**
https://oat-sa.atlassian.net/browse/PR-90
https://oat-sa.atlassian.net/browse/PR-89
https://oat-sa.atlassian.net/browse/PR-88

**Description:**
The three issues were related with permissions configuration for the _Completed_ and _Terminated_ statuses. Also for PR-89 I included the possibility of managing statuses permissions with functions and not just boolean values, so I had to make a small refactor of the `canDo` function, which now receives the full delivery and not only the state, so different properties of it can be used to check permissions. Regarding PR-90 there was a bug that was causing to request to the server to update the timer for both, the allowed and the denied resources, when multiple sessions were selected.

**Environment:** http://test-bosa.playground.kitchen.it.taocloud.org:49151/

**How to test:**

- Using LTI launch init a TTs session for a delivery with no time limits and check as a proctor that icon to add time for the session is hidden (rows 2-4 of attached image).
- Using LTI alunch init a TTs session for a delivery with time limits, check as a proctor that icon to add time for the session is enabled, terminate or complete the session, and check that the icon to add time for the session is hidden (rows 1 and 5 of attached image).
- Select multiple sessions where adding time is enabled only for some of them, click on the icon to add time as a bulk action. (check video).

![image](https://user-images.githubusercontent.com/14041944/100227313-3e43f780-2f21-11eb-8d15-aad4e66731d4.png)

![proctoring](https://user-images.githubusercontent.com/14041944/100227508-8cf19180-2f21-11eb-8b48-b7c0373c9fb9.gif)
