### PR TITLE
Fix/pr 89/include reason on rejected bulk time updates

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.20.1',
+    'version' => '19.20.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=45.6.3',

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -519,7 +519,7 @@ define([
                         }
 
                         if(!formatted.allowed){
-                            formatted.reason = canDo(actionName, testTakerData);
+                            formatted.reason = _.isFunction(status.can[actionName])? status.can[actionName](testTakerData) : status.can[actionName]; 
                             formatted.warning = status.warning[actionName] ?
                                 status.warning[actionName](null, testTakerData.id) :
                                 __('Unable to perform action on test %s.', testTakerData.id);

--- a/views/js/helper/status.js
+++ b/views/js/helper/status.js
@@ -38,7 +38,10 @@ define(['lodash', 'i18n'], function(_, __){
                 print : __('not finished'),
                 reactivate : __('not terminated'),
                 time : function(delivery) {
-                    return delivery.timer.remaining_time > 0;
+                    if (delivery.timer.remaining_time > 0) {
+                        return true;
+                    }
+                    return __('test has no time limits');
                 },
                 changeTime: __('in progress'),
             },
@@ -238,7 +241,7 @@ define(['lodash', 'i18n'], function(_, __){
                 reactivate : __('not terminated'),
                 report : true,
                 print: true,
-                time : false,
+                time :  __('completed'),
                 changeTime: __('completed'),
             },
             warning : {
@@ -343,7 +346,7 @@ define(['lodash', 'i18n'], function(_, __){
                 report : true,
                 reactivate : true,
                 print: true,
-                time : false,
+                time : __('terminated'),
                 changeTime: __('terminated'),
             },
             warning : {

--- a/views/js/helper/status.js
+++ b/views/js/helper/status.js
@@ -34,7 +34,7 @@ define(['lodash', 'i18n'], function(_, __){
      * @returns {boolean | string } - returns true if adding extra time is possible, reason of denied if not
      */
     function canAddExtraTime (delivery) {
-        return delivery.timer.remaining_time > 0 ||__('test has no time limits');
+        return delivery.timer.remaining_time > 0 || __('test has no time limits');
     }
 
     var _status = {

--- a/views/js/helper/status.js
+++ b/views/js/helper/status.js
@@ -34,10 +34,7 @@ define(['lodash', 'i18n'], function(_, __){
      * @returns {boolean | string } - returns true if adding extra time is possible, reason of denied if not
      */
     function canAddExtraTime (delivery) {
-        if (delivery.timer.remaining_time > 0) {
-            return true;
-        }
-        return __('test has no time limits');
+        return delivery.timer.remaining_time > 0 ||__('test has no time limits');
     }
 
     var _status = {

--- a/views/js/helper/status.js
+++ b/views/js/helper/status.js
@@ -25,6 +25,20 @@ define(['lodash', 'i18n'], function(_, __){
         _completed = 'http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusFinished',
         _terminated = 'http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusTerminated',
         _canceled = 'http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecutionStatusCanceled';
+        
+    /**
+     * Checks if adding extra time should be possible or not for the given delivery.
+     * Adding extra time will be possible if the delivery contains sections
+     * with time limits.
+     * @param {Object} delivery - delivery to check
+     * @returns {boolean | string } - returns true if adding extra time is possible, reason of denied if not
+     */
+    function canAddExtraTime (delivery) {
+        if (delivery.timer.remaining_time > 0) {
+            return true;
+        }
+        return __('test has no time limits');
+    }
 
     var _status = {
         inprogress : {
@@ -37,12 +51,7 @@ define(['lodash', 'i18n'], function(_, __){
                 report : true,
                 print : __('not finished'),
                 reactivate : __('not terminated'),
-                time : function(delivery) {
-                    if (delivery.timer.remaining_time > 0) {
-                        return true;
-                    }
-                    return __('test has no time limits');
-                },
+                time: canAddExtraTime,
                 changeTime: __('in progress'),
             },
             warning : {
@@ -85,12 +94,7 @@ define(['lodash', 'i18n'], function(_, __){
                 pause : __('not started'), //not in progress
                 print : __('not finished'),
                 reactivate : __('not terminated'),
-                time : function(delivery) {
-                    if (delivery.timer.remaining_time > 0) {
-                        return true;
-                    }
-                    return __('test has no time limits');
-                },
+                time: canAddExtraTime,
                 changeTime: __('authorized but not started'),
             },
             warning : {
@@ -142,12 +146,7 @@ define(['lodash', 'i18n'], function(_, __){
                 reactivate : __('not terminated'),
                 report : true,
                 print : __('not finished'),
-                time : function(delivery) {
-                    if (delivery.timer.remaining_time > 0) {
-                        return true;
-                    }
-                    return __('test has no time limits');
-                },
+                time : canAddExtraTime,
                 changeTime: __('awaiting'),
             },
             warning : {
@@ -304,12 +303,7 @@ define(['lodash', 'i18n'], function(_, __){
                 terminate : true,
                 report : true,
                 print : __('not finished'),
-                time : function(delivery) {
-                    if (delivery.timer.remaining_time > 0) {
-                        return true;
-                    }
-                    return __('test has no time limits');
-                },
+                time : canAddExtraTime,
                 changeTime: __('paused'),
             },
             warning : {

--- a/views/js/helper/status.js
+++ b/views/js/helper/status.js
@@ -85,7 +85,12 @@ define(['lodash', 'i18n'], function(_, __){
                 pause : __('not started'), //not in progress
                 print : __('not finished'),
                 reactivate : __('not terminated'),
-                time : true,
+                time : function(delivery) {
+                    if (delivery.timer.remaining_time > 0) {
+                        return true;
+                    }
+                    return __('test has no time limits');
+                },
                 changeTime: __('authorized but not started'),
             },
             warning : {
@@ -137,7 +142,12 @@ define(['lodash', 'i18n'], function(_, __){
                 reactivate : __('not terminated'),
                 report : true,
                 print : __('not finished'),
-                time : true,
+                time : function(delivery) {
+                    if (delivery.timer.remaining_time > 0) {
+                        return true;
+                    }
+                    return __('test has no time limits');
+                },
                 changeTime: __('awaiting'),
             },
             warning : {
@@ -180,7 +190,7 @@ define(['lodash', 'i18n'], function(_, __){
                 reactivate : __('not terminated'),
                 report : true,
                 print: __('canceled'),
-                time : true,
+                time : __('canceled'),
                 changeTime: __('canceled'),
             },
             warning : {
@@ -294,7 +304,12 @@ define(['lodash', 'i18n'], function(_, __){
                 terminate : true,
                 report : true,
                 print : __('not finished'),
-                time : true,
+                time : function(delivery) {
+                    if (delivery.timer.remaining_time > 0) {
+                        return true;
+                    }
+                    return __('test has no time limits');
+                },
                 changeTime: __('paused'),
             },
             warning : {


### PR DESCRIPTION
**Related to:** 
https://oat-sa.atlassian.net/browse/PR-90
https://oat-sa.atlassian.net/browse/PR-89

**See also:** https://github.com/oat-sa/extension-tao-proctoring/pull/861

**Description:** 
This PR fixes two problems noticed on QA phase:

-  Some statuses had to update the permission for adding extra time to a session.
- An error caused by refactor made on https://github.com/oat-sa/extension-tao-proctoring/pull/861 that was causing not to show the denied reason when trying to make a forbidden action on the bulk action modal.


**before:**
![image](https://user-images.githubusercontent.com/14041944/100604803-55129180-3307-11eb-8e6d-e6b4442bf9e6.png)

**now:**
![image](https://user-images.githubusercontent.com/14041944/100604768-488e3900-3307-11eb-8ccc-3a801281be3a.png)


