### PR TITLE
Fix/PR-142/filter date with one day selected

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.20.2',
+    'version' => '19.20.3',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=45.6.3',

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -933,19 +933,16 @@ define([
                             return locale.formatDateTime(value);
                         },
                         filterTransform(value) {
-                            var first;
-                            var last;
                             var dateFormat = locale.getDateTimeFormat().split(' ')[0];
                             var values = value.split(' ');
                             var result = '';
-
-                            if (values.length >= 2) {
-                                first = values[0];
-                                last = values[values.length - 1];
-
-                                result += moment(first, dateFormat).format('X');
+                            var start_day = values[0]
+                            var last_day = values[values.length - 1];
+                        
+                            if (start_day && last_day) {
+                                result += moment(start_day, dateFormat).format('X');
                                 result += ' - ';
-                                result += moment(last, dateFormat).add(1, 'd').format('X');
+                                result += moment(last_day, dateFormat).add(1, 'd').format('X');
                             }
 
                             return result;


### PR DESCRIPTION
**Related to task:**  https://oat-sa.atlassian.net/browse/PR-142
**Description:** The monitoring date filter must send to server start and end day to get the proper results.
When one day is selected the end day is not sending.
**How to test:** Steps to help reviewers to test the behavior
**Steps to reproduce:** 
- Login as NCCER admin
- Enter to the child organization
- Open the proctoring page
- On page load the current day is selected and results in table is showing for the current day.
- Click on "Reload" button

**Expected behavior:** The results on the table must be the same as on page load
**Actual behavior:** The results is displaying as date filter were not applied
