### PR TITLE
Fix/pr 142/proctoring start date filter

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.20.2',
+    'version' => '19.20.3',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=45.6.3',

--- a/model/execution/DeliveryExecutionList.php
+++ b/model/execution/DeliveryExecutionList.php
@@ -108,6 +108,9 @@ class DeliveryExecutionList extends ConfigurableService
 
         $executionState = $cachedData[DeliveryMonitoringService::STATUS];
 
+        $adjustedTime = $isTimerAdjustmentAllowed ? $this->getDeliveryExecutionManagerService()
+            ->getAdjustedTime($cachedData[DeliveryMonitoringService::DELIVERY_EXECUTION_ID]) : 0;
+
         $execution = array(
             'id' => $cachedData[DeliveryMonitoringService::DELIVERY_EXECUTION_ID],
             'delivery' => array(
@@ -129,8 +132,7 @@ class DeliveryExecutionList extends ConfigurableService
                     ? (float)$cachedData[DeliveryMonitoringService::EXTENDED_TIME]
                     : '',
                 'consumedExtraTime' => (float) ($cachedData[DeliveryMonitoringService::CONSUMED_EXTRA_TIME] ?? 0),
-                'adjustedTime' => $this->getDeliveryExecutionManagerService()
-                    ->getAdjustedTime($cachedData[DeliveryMonitoringService::DELIVERY_EXECUTION_ID])
+                'adjustedTime' => $adjustedTime
             ],
             'testTaker' => $this->createTestTaker($cachedData),
             'extraFields' => $extraFields,

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -519,7 +519,7 @@ define([
                         }
 
                         if(!formatted.allowed){
-                            formatted.reason = _.isFunction(status.can[actionName])? status.can[actionName](testTakerData) : status.can[actionName]; 
+                            formatted.reason = _.isFunction(status.can[actionName])? status.can[actionName](testTakerData) : status.can[actionName];
                             formatted.warning = status.warning[actionName] ?
                                 status.warning[actionName](null, testTakerData.id) :
                                 __('Unable to perform action on test %s.', testTakerData.id);
@@ -938,6 +938,7 @@ define([
                             var dateFormat = locale.getDateTimeFormat().split(' ')[0];
                             var values = value.split(' ');
                             var result = '';
+                            console.log(value, dateFormat)
 
                             if (values.length >= 2) {
                                 first = values[0];
@@ -958,6 +959,8 @@ define([
                                 var dateFormatStr = dateFormat[0];
                                 var lastValue;
 
+                                console.log(dateFormat);
+
                                 // the date time picker won't display otherwise
                                 $filterContainer.css('position', 'static');
 
@@ -966,7 +969,7 @@ define([
                                 }
 
                                 startDatePicker = dateTimePicker($filterContainer, {
-                                    setup: 'datetime-range',
+                                    setup: 'date-range',
                                     format: dateFormatStr,
                                     replaceField: $elt[0]
                                 })
@@ -1265,7 +1268,7 @@ define([
                                 setTagUsage(applyTags);
                             }
 
-                            
+
                             $list.datatable('highlightRows', highlightRows);
                             loadingBar.stop();
 

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -677,15 +677,6 @@ define([
                     });
                 }
 
-                /**
-                 * Return the default date range of one day
-                 * @returns {string}
-                 */
-                function getDefaultStartTimeFilter() {
-                    var dateFormat = locale.getDateTimeFormat().split(' ')[0];
-                    return `${moment().format(dateFormat)} to ${moment().add('1', 'd').format(dateFormat)}`;
-                }
-
                 function extractOption(object, option, defaultValue) {
                     return _.isUndefined(object[option], undefined) ? defaultValue : object[option];
                 }
@@ -947,7 +938,6 @@ define([
                                 result += ' - ';
                                 result += moment(last, dateFormat).add(1, 'd').format('X');
                             }
-
                             return result;
                         },
                         customFilter : {
@@ -965,11 +955,22 @@ define([
                                     startDatePicker.destroy();
                                 }
 
+                                console.log($elt.val())
+
                                 startDatePicker = dateTimePicker($filterContainer, {
                                     setup: 'date-range',
                                     format: dateFormatStr,
-                                    replaceField: $elt[0]
+                                    replaceField: $elt[0],
                                 })
+                                    .on('ready', function () {
+                                        // set default date range
+                                        if (setStartDataOneDay) {
+                                            const dateFormat = locale.getDateTimeFormat().split(' ')[0];
+                                            const from = moment().format(dateFormat);
+                                            const to = moment().add('1', 'd').format(dateFormat);
+                                            startDatePicker.setValue([from, to]);
+                                        }
+                                    })
                                     .on('change', function (value) {
                                         var selection = this.getSelectedDates();
                                         if ((value === '' && lastValue !== value) ||
@@ -1004,10 +1005,10 @@ define([
                                 status = _status.getStatusByCode(row.state.status);
                                 if (status) {
                                     result = status.label;
-                                    if (row.state.status === 'INPROGRESS') {
+                                    if (row.state.status === __('INPROGRESS')) {
                                         result = status.label;
                                     }
-                                    if (result === 'Awaiting') {
+                                    if (result === __('Awaiting')) {
                                         highlightRows.push(row.id);
                                     }
                                 }
@@ -1265,7 +1266,6 @@ define([
                                 setTagUsage(applyTags);
                             }
 
-
                             $list.datatable('highlightRows', highlightRows);
                             loadingBar.stop();
 
@@ -1308,7 +1308,6 @@ define([
                             atomicUpdate: !!data.autoRefresh,
                             filterStrategy: 'multiple',
                             filterSelector: 'select, input:not(.select2-input, .select2-focusser)',
-                            filtercolumns: {start_time: (setStartDataOneDay ? getDefaultStartTimeFilter() : "")},
                             filter: true,
                             tools: tools,
                             model: model,

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -938,7 +938,6 @@ define([
                             var dateFormat = locale.getDateTimeFormat().split(' ')[0];
                             var values = value.split(' ');
                             var result = '';
-                            console.log(value, dateFormat)
 
                             if (values.length >= 2) {
                                 first = values[0];
@@ -958,8 +957,6 @@ define([
                                 var dateFormat = locale.getDateTimeFormat().split(' ');
                                 var dateFormatStr = dateFormat[0];
                                 var lastValue;
-
-                                console.log(dateFormat);
 
                                 // the date time picker won't display otherwise
                                 $filterContainer.css('position', 'static');

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -955,8 +955,6 @@ define([
                                     startDatePicker.destroy();
                                 }
 
-                                console.log($elt.val())
-
                                 startDatePicker = dateTimePicker($filterContainer, {
                                     setup: 'date-range',
                                     format: dateFormatStr,


### PR DESCRIPTION
Pull request summary
 
Related to: https://oat-sa.atlassian.net/browse/PR-142
 
- datetime-range replaced with date-rage as proctoring never worked with H:s (it was added by mistake when new datetime picker was added) [here](https://github.com/oat-sa/extension-tao-proctoring/pull/866/files#diff-92ee372f909de10dcd3ebee0c4539e6f9bcf7acb9ef00aca5bedbc930ba7002aR961)
- Deleted time adjustment error log, for the test sessions that can’t use it (thousands records in the log, that we don’t need) [here](https://github.com/oat-sa/extension-tao-proctoring/pull/866/files#diff-ef33637e6c90a7eda0155ee4cca8ac1f1e0b3f660cc7812e4db2dedb2c68c2bbR111)
- Issue with localization of the datetime picker, it should be initialized with datepicker component, not manually [here](https://github.com/oat-sa/extension-tao-proctoring/pull/866/files#diff-92ee372f909de10dcd3ebee0c4539e6f9bcf7acb9ef00aca5bedbc930ba7002aR965)
- line highlighting - delivery executions in the awaiting state should be highlighted, but it doesn’t work for the other then EN langs [here](https://github.com/oat-sa/extension-tao-proctoring/pull/866/files#diff-92ee372f909de10dcd3ebee0c4539e6f9bcf7acb9ef00aca5bedbc930ba7002aR1008)
 
#### Steps to reproduce  (for bugs)
__datetime-range__
 - datepicker has fields for the hours and seconds

 __logs__
- When the test taker is waiting for the approval from the proctor and proctor is on the proctoring page - there are a lot of errors in the log about the adjustment time, which generated on each datatable update

__highlights__
- delivery executions in the state AWAITING are not highlighted for the languages different from En

__datepicker__
- when the language different than En there is only 1 date in the date range picker by default
  
#### How to test
 
__datetime-range__
- there are no Hours and seconds in the date range picker

__logs__
- there are no records in the log about the adjustment time, when delivery execution can't be adjusted

__highlights__
- each language highlights delivery executions in the state PAUSE

__datepicker__
- default value of the datepicker is localized