### PR TITLE
fix: datePicker value should be saved on the datatable refresh action

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.20.3',
+    'version' => '19.20.4',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=45.6.3',

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -94,6 +94,7 @@ define([
     var executionsUrl = urlHelper.route('deliveryExecutions', 'Monitor', 'taoProctoring');
     var historyUrl = urlHelper.route('index', 'Reporting', 'taoProctoring');
     const adjustTimeUrl = urlHelper.route('adjustTime', 'Monitor', 'taoProctoring');
+    let datePickerDate = null;
 
 
     /**
@@ -962,15 +963,17 @@ define([
                                 })
                                     .on('ready', function () {
                                         // set default date range
-                                        if (setStartDataOneDay) {
+                                        if (setStartDataOneDay && !datePickerDate) {
                                             const dateFormat = locale.getDateTimeFormat().split(' ')[0];
                                             const from = moment().format(dateFormat);
                                             const to = moment().add('1', 'd').format(dateFormat);
-                                            startDatePicker.setValue([from, to]);
+                                            datePickerDate = [from, to];
                                         }
+                                        startDatePicker.setValue(datePickerDate);
                                     })
                                     .on('change', function (value) {
-                                        var selection = this.getSelectedDates();
+                                        const selection = this.getSelectedDates();
+                                        datePickerDate = selection;
                                         if ((value === '' && lastValue !== value) ||
                                             (selection && selection.length === 2)) {
                                             $list.datatable('filter');

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -952,20 +952,18 @@ define([
                             return locale.formatDateTime(value);
                         },
                         filterTransform(value) {
-                            var first;
-                            var last;
                             var dateFormat = locale.getDateTimeFormat().split(' ')[0];
                             var values = value.split(' ');
                             var result = '';
 
-                            if (values.length >= 2) {
-                                first = values[0];
-                                last = values[values.length - 1];
-
-                                result += moment(first, dateFormat).format('X');
+                            const start_day = values[0];
+                            const last_day = values[values.length - 1];
+                            if (start_day && last_day) {
+                                result += moment(start_day, dateFormat).format('X');
                                 result += ' - ';
-                                result += moment(last, dateFormat).add(1, 'd').format('X');
+                                result += moment(last_day, dateFormat).add(1, 'd').format('X');
                             }
+
                             return result;
                         },
                         customFilter : {
@@ -988,13 +986,11 @@ define([
                                     format: dateFormatStr,
                                     replaceField: $elt[0],
                                 })
-                                    .on('change', function (value) {
+                                    .on('close', function () {
                                         const selection = this.getSelectedDates();
-                                        if ((value === '' && lastValue !== value) ||
-                                            (selection && selection.length === 2)) {
+                                        if (selection.length === 2) {
                                             $list.datatable('filter');
                                         }
-                                        lastValue = value;
                                     })
                                     .on('clear', function () {
                                         $list.datatable('filter');


### PR DESCRIPTION
Pull request summary
 
Related to: https://oat-sa.atlassian.net/browse/PR-142
 
Default date range should not be updated to default value on the datatable refresh action.
 
#### Steps to reproduce  (for bugs)
 - Chose date range different then default
 - Datatable reloads the data automatically with default date range
  
#### How to test
 - Chose date range different then default
 - Datatable shows us the correct data
