### PR TITLE
fix: checkboxes should be pured after the action success completion

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.20.5',
+    'version' => '19.20.6',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=45.6.3',

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -245,6 +245,7 @@ define([
                                 if (message) {
                                     feedback().success(message);
                                 }
+                                $list.trigger('reset-checkboxes');
                                 $list.datatable('refresh');
                             })
                             .catch(function(err) {
@@ -972,7 +973,6 @@ define([
                                 var $filterContainer = $elt.closest('.filter');
                                 var dateFormat = locale.getDateTimeFormat().split(' ');
                                 var dateFormatStr = dateFormat[0];
-                                var lastValue;
 
                                 // the date time picker won't display otherwise
                                 $filterContainer.css('position', 'static');
@@ -1287,6 +1287,14 @@ define([
                                 .on('change.polling', function () {
                                     polling.stop();
                                 });
+
+                            $list.off('reset-checkboxes').on('reset-checkboxes', function(a) {
+                                const $checkboxes = $list.find('td.checkboxes input');
+                                const $checkAll = $list.find('th.checkboxes input');
+
+                                $checkAll.prop('checked', false);
+                                $checkboxes.prop('checked', false);
+                            });
 
                             polling.start();
                             timer.resume();


### PR DESCRIPTION
Pull request summary
 
Related to: https://oat-sa.atlassian.net/browse/PR-157

Summary:On the Proctor Console, when you select a test by clicking the checkbox next to it-- it remains checked even after you've terminated it, added time to it, refreshed the console, etc.

Actual Results:After you perform a function (terminate, add time, refresh page), the checkbox remains checked.

Expected Results:Currently, on Prod, after you perform a function (terminate, add time, refresh page), the checkbox is no longer checked. 

Steps to Reproduce:
Log into Pre-Prod as an Instructor/Proctor (I used Don Whyte Test - 28745).
Go to Child Org (I used Rock 'n' Roll High School).
Select Proctor Console.
Check the checkbox next to a test in progress.
Terminate the test.
The checkbox will remain checked even after the function is done.