### PR TITLE
fix(monitoring): fix display of tt names with special characters

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.20.7',
+    'version' => '19.20.8',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=45.6.3',

--- a/views/js/controller/Delivery/monitoring.js
+++ b/views/js/controller/Delivery/monitoring.js
@@ -1247,6 +1247,12 @@ define([
                             highlightRows = [];
                         })
                         .on('load.datatable', function(e, newDataset) {
+                            if (newDataset.data) {
+                                newDataset.data.forEach(session => {
+                                    session.test_taker_first_name = session.test_taker_first_name ? $('<div>').html(session.test_taker_first_name).text() : undefined;
+                                    session.test_taker_last_name = session.test_taker_last_name ? $('<div>').html(session.test_taker_last_name).text() : undefined;
+                                })
+                            }                            
                             var applyTags;
 
                             //update dateset in memory


### PR DESCRIPTION
**Related to:** https://oat-sa.atlassian.net/browse/PR-190

**Description**
TT names with special characters (eg.: _ë, û, €, é_) are not being correctly rendered. Strings are originally received wrongly decoded from BE, so now they are directly parsed once datatable component notifies the new dataset. To do so jQuery `html` method is used to decode the string into a temporary div element (that is never appended to document) and then its content is extracted with jQuery `text`.

![image](https://user-images.githubusercontent.com/14041944/105201832-9a05b800-5b41-11eb-8a91-f098aa36e16b.png)
