### PR TITLE
Fix/PR-202/time adjustment displaying

### DIFF
--- a/model/execution/DeliveryExecutionList.php
+++ b/model/execution/DeliveryExecutionList.php
@@ -108,9 +108,6 @@ class DeliveryExecutionList extends ConfigurableService
 
         $executionState = $cachedData[DeliveryMonitoringService::STATUS];
 
-        $adjustedTime = $isTimerAdjustmentAllowed ? $this->getDeliveryExecutionManagerService()
-            ->getAdjustedTime($cachedData[DeliveryMonitoringService::DELIVERY_EXECUTION_ID]) : 0;
-
         $execution = array(
             'id' => $cachedData[DeliveryMonitoringService::DELIVERY_EXECUTION_ID],
             'delivery' => array(
@@ -132,7 +129,8 @@ class DeliveryExecutionList extends ConfigurableService
                     ? (float)$cachedData[DeliveryMonitoringService::EXTENDED_TIME]
                     : '',
                 'consumedExtraTime' => (float) ($cachedData[DeliveryMonitoringService::CONSUMED_EXTRA_TIME] ?? 0),
-                'adjustedTime' => $adjustedTime
+                'adjustedTime' => $this->getDeliveryExecutionManagerService()
+                    ->getAdjustedTime($cachedData[DeliveryMonitoringService::DELIVERY_EXECUTION_ID] ?? '')
             ],
             'testTaker' => $this->createTestTaker($cachedData),
             'extraFields' => $extraFields,


### PR DESCRIPTION
**Related to:** https://oat-sa.atlassian.net/browse/PR-202

**Description:** The bug was introduced in this [commit](https://github.com/oat-sa/extension-tao-proctoring/commit/607ce4412b98e3dd09219e7fe86b46d637ded685). The adjusted time displaying was allowed only when time adjustment itself was allowed, which led to the case when adjusted time value was showing up only when current delivery execution had "Awaiting" state.