### PR TITLE
fix: Fixed QTI duration class name.

### DIFF
--- a/model/implementation/TestSessionService.php
+++ b/model/implementation/TestSessionService.php
@@ -31,7 +31,7 @@ use oat\taoQtiTest\models\runner\config\QtiRunnerConfig;
 use oat\taoQtiTest\models\runner\session\TestSession;
 use oat\taoQtiTest\models\runner\time\QtiTimeConstraint;
 use oat\taoQtiTest\models\TestSessionService as QtiTestSessionService;
-use qtism\common\datatypes\Duration;
+use qtism\common\datatypes\QtiDuration;
 use qtism\runtime\tests\AssessmentTestSession;
 
 /**
@@ -259,7 +259,7 @@ class TestSessionService extends QtiTestSessionService
         $remainingTime = PHP_INT_MAX;
         /** @var QtiTimeConstraint $constraint */
         foreach ($constraints as $constraint) {
-            /** @var Duration $constraintRemainingDuration */
+            /** @var QtiDuration $constraintRemainingDuration */
             $constraintRemainingDuration = $constraint->getMaximumRemainingTime();
             if ($constraintRemainingDuration === false) {
                 continue;

--- a/test/unit/model/execution/DeliveryExecutionManagerServiceTest.php
+++ b/test/unit/model/execution/DeliveryExecutionManagerServiceTest.php
@@ -48,7 +48,7 @@ use oat\taoQtiTest\models\runner\time\QtiTimeConstraint;
 use oat\taoQtiTest\models\runner\time\QtiTimer;
 use oat\taoQtiTest\models\runner\time\TimerAdjustmentService;
 use oat\taoQtiTest\models\runner\time\TimerAdjustmentServiceInterface;
-use qtism\common\datatypes\Duration;
+use qtism\common\datatypes\QtiDuration;
 use qtism\data\QtiIdentifiable;
 
 class DeliveryExecutionManagerServiceTest extends TestCase
@@ -219,7 +219,7 @@ class DeliveryExecutionManagerServiceTest extends TestCase
 
 
         // Setup TestSessionService mock
-        $durationMock = $this->createMock(Duration::class);
+        $durationMock = $this->createMock(QtiDuration::class);
         $durationMock->method('getSeconds')
             ->willReturn($expectedLimit);
         $qtiTimeConstraintMock = $this->createMock(QtiTimeConstraint::class);

--- a/test/unit/model/execution/implementation/TestSessionServiceTest.php
+++ b/test/unit/model/execution/implementation/TestSessionServiceTest.php
@@ -25,7 +25,7 @@ use oat\generis\test\TestCase;
 use oat\taoProctoring\model\implementation\TestSessionService;
 use oat\taoQtiTest\models\runner\session\TestSession;
 use oat\taoQtiTest\models\runner\time\QtiTimeConstraint;
-use qtism\common\datatypes\Duration;
+use qtism\common\datatypes\QtiDuration;
 use qtism\runtime\tests\TimeConstraintCollection;
 
 class TestSessionServiceTest extends TestCase
@@ -120,11 +120,11 @@ class TestSessionServiceTest extends TestCase
 
     /**
      * @param int $maxRemainingTime
-     * @return Duration
+     * @return QtiDuration
      */
-    private function mockQtiDuration(int $maxRemainingTime): Duration
+    private function mockQtiDuration(int $maxRemainingTime): QtiDuration
     {
-        $durationMock = $this->createMock(Duration::class);
+        $durationMock = $this->createMock(QtiDuration::class);
         $durationMock->method('getSeconds')
             ->willReturn($maxRemainingTime);
 
@@ -132,7 +132,7 @@ class TestSessionServiceTest extends TestCase
     }
 
     /**
-     * @param Duration|bool $maxRemainingTime
+     * @param QtiDuration|bool $maxRemainingTime
      * @return QtiTimeConstraint|MockObject
      */
     private function mockQtiTimeConstraint($duration): QtiTimeConstraint


### PR DESCRIPTION
Fixed QTI duration class name in tests and phpdoc.
No functionality change.