### PR TITLE
Feature/pr 470/make delivery logging configurable

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.18.5',
+    'version' => '19.18.5.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=41.9.1',

--- a/test/integration/deliveryLog/RdsDeliveryLogServiceTest.php
+++ b/test/integration/deliveryLog/RdsDeliveryLogServiceTest.php
@@ -21,12 +21,16 @@
 
 namespace oat\taoProctoring\test\integration\monitorCache;
 
-require_once dirname(__FILE__).'/../../../../tao/includes/raw_start.php';
-
-use oat\tao\test\TaoPhpUnitTestRunner;
+use oat\generis\persistence\PersistenceManager;
+use oat\generis\test\SqlMockTrait;
+use oat\generis\test\TestCase;
+use oat\oatbox\event\EventManager;
+use oat\oatbox\session\SessionService;
+use oat\oatbox\user\User;
 use oat\taoDelivery\model\execution\Delete\DeliveryExecutionDeleteRequest;
 use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
 use oat\taoProctoring\model\deliveryLog\implementation\RdsDeliveryLogService;
+use oat\taoProctoring\scripts\install\RegisterProctoringLog;
 
 /**
  * class DeliveryMonitoringData
@@ -36,8 +40,10 @@ use oat\taoProctoring\model\deliveryLog\implementation\RdsDeliveryLogService;
  * @package oat\taoProctoring
  * @author Aleh Hutnikau <hutnikau@1pt.com>
  */
-class RdsDeliveryLogServiceTest extends TaoPhpUnitTestRunner
+class RdsDeliveryLogServiceTest extends TestCase
 {
+    use SqlMockTrait;
+
     /**
      * @var RdsDeliveryLogService
      */
@@ -45,32 +51,52 @@ class RdsDeliveryLogServiceTest extends TaoPhpUnitTestRunner
     private $persistence;
     private $deliveryExecutionId = 'http://sample/first.rdf#i1450191587554180_test_record';
 
-    /**
-     * Set up test
-     */
-    public function setUp(): void
+    protected function setUp(): void
     {
-        TaoPhpUnitTestRunner::initTest();
-        $this->service = new RdsDeliveryLogService(array(RdsDeliveryLogService::OPTION_PERSISTENCE => 'default',
-            'fields' => array(
-                'event_id',
-                'created_by',
-                'delivery_execution_id'
-            )));
-        $this->persistence = \common_persistence_Manager::getPersistence('default');
+        parent::setUp();
+        // Mock persistence
+        $persistenceId = 'delivery_log_test';
+        $persistenceManager = $this->getSqlMock($persistenceId);
+        $this->persistence = $persistenceManager->getPersistenceById($persistenceId);
+        (new RegisterProctoringLog())->createTable($this->persistence);
+
+        // Mock user
+        $userMock = $this->createMock(User::class);
+        $userMock->method('getIdentifier')->willReturn('TEST_USER_ID');
+        $sessionServiceMock = $this->createMock(SessionService::class);
+        $sessionServiceMock->method('getCurrentUser')
+            ->willReturn($userMock);
+
+        $slMock = $this->getServiceLocatorMock(
+            [
+                SessionService::SERVICE_ID => $sessionServiceMock,
+                PersistenceManager::SERVICE_ID => $persistenceManager,
+                EventManager::SERVICE_ID => $this->createMock(EventManager::class),
+            ]
+        );
+
+        $this->service = new RdsDeliveryLogService(
+            [
+                RdsDeliveryLogService::OPTION_PERSISTENCE => $persistenceId,
+                'fields' => [
+                    'event_id',
+                    'created_by',
+                    'delivery_execution_id'
+                ]
+            ]
+        );
+        $this->service->setServiceLocator($slMock);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->deleteTestData();
     }
 
     /**
      * Clear test data before and after each test method
-     * @after
-     * @before
      */
-    public function deleteTestData()
+    public function deleteTestData(): void
     {
         $sql = 'DELETE FROM ' . RdsDeliveryLogService::TABLE_NAME .
             ' WHERE ' . RdsDeliveryLogService::DELIVERY_EXECUTION_ID . " LIKE '%_test_record'";
@@ -79,14 +105,10 @@ class RdsDeliveryLogServiceTest extends TaoPhpUnitTestRunner
         $this->persistence->exec($sql);
     }
 
-    /**
-     * @dataProvider getLogData
-     * @param $deliveryExecutionId
-     */
-    public function testSearch($deliveryExecutionId)
+    public function testSearch(): void
     {
-        $this->service->log($deliveryExecutionId, 'test_event_same_uniq_1', 'test_val_1');
-        $this->service->log($deliveryExecutionId, 'test_event_same_uniq_1', 'test_val_2');
+        $this->service->log($this->deliveryExecutionId, 'test_event_same_uniq_1', 'test_val_1');
+        $this->service->log($this->deliveryExecutionId, 'test_event_same_uniq_1', 'test_val_2');
 
         $loggedData = $this->service->search([
             'event_id' => 'test_event_same_uniq_1',
@@ -98,47 +120,46 @@ class RdsDeliveryLogServiceTest extends TaoPhpUnitTestRunner
         $this->assertEquals(2, count($loggedData));
 
         $firstLog = $loggedData[0];
-        $this->assertEquals($deliveryExecutionId, $firstLog[RdsDeliveryLogService::DELIVERY_EXECUTION_ID]);
+        $this->assertEquals($this->deliveryExecutionId, $firstLog[RdsDeliveryLogService::DELIVERY_EXECUTION_ID]);
         $this->assertEquals('test_event_same_uniq_1', $firstLog[RdsDeliveryLogService::EVENT_ID]);
         $this->assertEquals('test_val_2', $firstLog[RdsDeliveryLogService::DATA]);
 
         $secondLog = $loggedData[1];
-        $this->assertEquals($deliveryExecutionId, $secondLog[RdsDeliveryLogService::DELIVERY_EXECUTION_ID]);
+        $this->assertEquals($this->deliveryExecutionId, $secondLog[RdsDeliveryLogService::DELIVERY_EXECUTION_ID]);
         $this->assertEquals('test_event_same_uniq_1', $secondLog[RdsDeliveryLogService::EVENT_ID]);
         $this->assertEquals('test_val_1', $secondLog[RdsDeliveryLogService::DATA]);
     }
 
-    /**
-     * @dataProvider getLogData
-     * @param $deliveryExecutionId
-     */
-    public function testDelete($deliveryExecutionId)
+    public function testDelete(): void
     {
-        $this->service->log($deliveryExecutionId, 'test_event_same_uniq_2', 'test_val_1');
+        $this->service->log($this->deliveryExecutionId, 'test_event_same_uniq_2', 'test_val_1');
+        $this->assertEquals(1, $this->getLogRecordsCount(), 'Log record must be stored in DB.');
 
-        $executionMock = $this->getMockBuilder(DeliveryExecutionInterface::class)->getMock();
-        $executionMock
-            ->method('getIdentifier')
-            ->willReturn($deliveryExecutionId);
+        $executionMock = $this->createMock(DeliveryExecutionInterface::class);
+        $executionMock->method('getIdentifier')
+            ->willReturn($this->deliveryExecutionId);
 
-        $request = $this->getMockBuilder(DeliveryExecutionDeleteRequest::class)->disableOriginalConstructor()->getMock();
-        $request
-            ->method('getDeliveryExecution')
+        $request = $this->createMock(DeliveryExecutionDeleteRequest::class);
+        $request->method('getDeliveryExecution')
             ->willReturn($executionMock);
 
         $this->assertTrue($this->service->deleteDeliveryExecutionData($request));
     }
+
     /**
-     * @dataProvider getLogData
      * @param $deliveryExecutionId
      * @param $eventId
      * @param $data
      * @param string $userId
+     *
+     * @dataProvider dataProviderLogData
      */
-    public function testLog($deliveryExecutionId, $eventId, $data, $userId)
+    public function testLog($deliveryExecutionId, $eventId, $data, $userId): void
     {
+        $this->assertEquals(0, $this->getLogRecordsCount(), 'Log table must be empty before tests.');
         $result = $this->service->log($deliveryExecutionId, $eventId, $data, $userId);
         $this->assertTrue($result);
+        $this->assertEquals(1, $this->getLogRecordsCount(), 'Log record must be stored in DB.');
 
         $loggedData = $this->getRecordByDeliveryExecutionId($deliveryExecutionId);
 
@@ -156,14 +177,14 @@ class RdsDeliveryLogServiceTest extends TaoPhpUnitTestRunner
         }
     }
 
-
     /**
-     * @dataProvider getLogData
      * @param $deliveryExecutionId
      * @param $eventId
      * @param $data
+     *
+     * @dataProvider dataProviderLogData
      */
-    public function testGet($deliveryExecutionId, $eventId, $data)
+    public function testGet($deliveryExecutionId, $eventId, $data): void
     {
         $this->service->log($deliveryExecutionId, $eventId, $data);
         $this->service->log($deliveryExecutionId, 'test', 'test_val');
@@ -186,9 +207,8 @@ class RdsDeliveryLogServiceTest extends TaoPhpUnitTestRunner
 
     /**
      * Get data to be logged
-     * @return array
      */
-    public function getLogData()
+    public function dataProviderLogData(): array
     {
         return [
             [
@@ -211,14 +231,17 @@ class RdsDeliveryLogServiceTest extends TaoPhpUnitTestRunner
 
     /**
      * Get logged data from database
-     * @param string $id delivery execution id
-     * @return array
      */
-    private function getRecordByDeliveryExecutionId($id)
+    private function getRecordByDeliveryExecutionId(string $id): array
     {
         $sql = 'SELECT * FROM ' . RdsDeliveryLogService::TABLE_NAME .
             ' WHERE ' . RdsDeliveryLogService::DELIVERY_EXECUTION_ID . '=?';
 
         return $this->persistence->query($sql, [$id])->fetchAll();
+    }
+
+    private function getLogRecordsCount(): int
+    {
+        return (int) $this->persistence->exec('SELECT count(*) FROM delivery_log');
     }
 }


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/PR-470

To reduce load on DB added config option which allows to disable delivery logs storing.
Logging is enabled by default. To disable add new option in `taoProctoring/DeliveryLog.conf.php`:
```
return new oat\taoProctoring\model\deliveryLog\implementation\RdsDeliveryLogService(array(
    ... 
    'enable_logging' => false
)); 
```