### PR TITLE
feat: create script to migrate data from kv to amin table

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.18.5',
+    'version' => '19.18.5.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=41.9.1',

--- a/migrations/Version202106081338544101_taoProctoring.php
+++ b/migrations/Version202106081338544101_taoProctoring.php
@@ -1,4 +1,22 @@
 <?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA
+ *
+ */
 
 declare(strict_types=1);
 
@@ -13,12 +31,8 @@ use oat\generis\persistence\PersistenceManager;
 use oat\tao\scripts\tools\migrations\AbstractMigration;
 use oat\taoProctoring\model\monitorCache\implementation\SimpleMonitoringStorage;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 final class Version202106081338544101_taoProctoring extends AbstractMigration
 {
-
     public function getDescription(): string
     {
         return 'Creates new `extra_data` column in `delivery_monitoring` to store extra data.';
@@ -37,7 +51,7 @@ final class Version202106081338544101_taoProctoring extends AbstractMigration
                 $table = $schema->getTable(SimpleMonitoringStorage::TABLE_NAME);
                 $table->addColumn(SimpleMonitoringStorage::COLUMN_EXTRA_DATA, Types::JSON, array("notnull" => false));
                 $persistence->getPlatForm()->migrateSchema($fromSchema, $schema);
-            } else if ($platformName == 'postgresql') {
+            } elseif ($platformName == 'postgresql') {
                 $query = sprintf(
                     'ALTER TABLE %s ADD COLUMN %s jsonb',
                     SimpleMonitoringStorage::TABLE_NAME,
@@ -60,7 +74,6 @@ final class Version202106081338544101_taoProctoring extends AbstractMigration
                 )
             );
         }
-
     }
 
     public function down(Schema $schema): void

--- a/migrations/Version202106081338544101_taoProctoring.php
+++ b/migrations/Version202106081338544101_taoProctoring.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoProctoring\migrations;
+
+use Exception;
+use common_report_Report as Report;
+use common_persistence_SqlPersistence;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use oat\generis\persistence\PersistenceManager;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoProctoring\model\monitorCache\implementation\SimpleMonitoringStorage;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version202106081338544101_taoProctoring extends AbstractMigration
+{
+
+    public function getDescription(): string
+    {
+        return 'Creates new `extra_data` column in `delivery_monitoring` to store extra data.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        try {
+            $persistence = $this->getPersistence();
+
+            $platformName = $persistence->getPlatForm()->getName();
+            if ($platformName == 'mysql') {
+                $schema = $persistence->getSchemaManager()->createSchema();
+                $fromSchema = clone $schema;
+
+                $table = $schema->getTable(SimpleMonitoringStorage::TABLE_NAME);
+                $table->addColumn(SimpleMonitoringStorage::COLUMN_EXTRA_DATA, Types::JSON, array("notnull" => false));
+                $persistence->getPlatForm()->migrateSchema($fromSchema, $schema);
+            } else if ($platformName == 'postgresql') {
+                $query = sprintf(
+                    'ALTER TABLE %s ADD COLUMN %s jsonb',
+                    SimpleMonitoringStorage::TABLE_NAME,
+                    SimpleMonitoringStorage::COLUMN_EXTRA_DATA
+                );
+                $persistence->exec($query);
+            } else {
+                throw new Exception("Unsupported platform: $platformName");
+            }
+            $this->addReport(Report::createSuccess('`extra_data` column was created in `delivery_monitoring` table'));
+        } catch (Exception $e) {
+            $this->addReport(
+                new Report(
+                    Report::TYPE_ERROR,
+                    'Failed to create `extra_data` column in `delivery_monitoring`',
+                    [
+                        'message' => $e->getMessage(),
+                        'trace' => $e->getTrace(),
+                    ]
+                )
+            );
+        }
+
+    }
+
+    public function down(Schema $schema): void
+    {
+        $persistence = $this->getPersistence();
+        $schema = $persistence->getSchemaManager()->createSchema();
+        $fromSchema = clone $schema;
+
+        $table = $schema->getTable(SimpleMonitoringStorage::TABLE_NAME);
+        if ($table->hasColumn(SimpleMonitoringStorage::COLUMN_EXTRA_DATA)) {
+            $table->dropColumn(SimpleMonitoringStorage::COLUMN_EXTRA_DATA);
+        }
+        $persistence->getPlatForm()->migrateSchema($fromSchema, $schema);
+        $this->addReport(Report::createSuccess('`extra_data` column was deleted in `delivery_monitoring` table'));
+    }
+
+    private function getPersistence(): common_persistence_SqlPersistence
+    {
+        return $this->getServiceLocator()
+            ->get(PersistenceManager::SERVICE_ID)
+            ->getPersistenceById('default');
+    }
+}

--- a/model/datatable/DeliveriesActivityDatatable.php
+++ b/model/datatable/DeliveriesActivityDatatable.php
@@ -26,6 +26,7 @@ use oat\tao\model\datatable\DatatablePayload;
 use oat\oatbox\service\ServiceManager;
 use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
 use oat\taoProctoring\model\ActivityMonitoringService;
+use oat\taoProctoring\model\monitorCache\implementation\MonitoringStorage;
 use Zend\ServiceManager\ServiceLocatorAwareInterface;
 use Zend\ServiceManager\ServiceLocatorAwareTrait;
 
@@ -60,8 +61,8 @@ class DeliveriesActivityDatatable implements DatatablePayload, ServiceLocatorAwa
 
     public function getPayload()
     {
-        /** @var \oat\taoProctoring\model\monitorCache\implementation\MonitoringStorage $service */
-        $service = $this->getServiceLocator()->get(\oat\taoProctoring\model\monitorCache\implementation\MonitoringStorage::SERVICE_ID);
+        /** @var MonitoringStorage $service */
+        $service = $this->getServiceLocator()->get(MonitoringStorage::SERVICE_ID);
 
         $offset = ($this->request->getPage() - 1) * $this->request->getRows() ? : 0;
         $limit = $this->request->getRows() ? : 0;
@@ -81,8 +82,8 @@ class DeliveriesActivityDatatable implements DatatablePayload, ServiceLocatorAwa
      */
     protected function doPostProcessing(array $result)
     {
-        /** @var \oat\taoProctoring\model\monitorCache\implementation\MonitoringStorage $service */
-        $service = $this->getServiceLocator()->get(\oat\taoProctoring\model\monitorCache\implementation\MonitoringStorage::SERVICE_ID);
+        /** @var MonitoringStorage $service */
+        $service = $this->getServiceLocator()->get(MonitoringStorage::SERVICE_ID);
         $rows = $this->request->getRows();
         $rows = $rows?:1;
         $total = $service->getCountOfStatistics();

--- a/model/monitorCache/implementation/MonitorCacheService.php
+++ b/model/monitorCache/implementation/MonitorCacheService.php
@@ -26,7 +26,6 @@ use oat\generis\model\OntologyRdfs;
 use oat\tao\model\taskQueue\QueueDispatcherInterface;
 use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
 use oat\taoDelivery\model\execution\DeliveryExecutionService;
-use oat\taoDelivery\model\execution\ServiceProxy;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionCreated;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionReactivated;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState;
@@ -49,7 +48,7 @@ use oat\taoProctoring\model\authorization\AuthorizationGranted;
  * @package oat\taoProctoring\model
  * @author Aleh Hutnikau <hutnikau@1pt.com>
  */
-class MonitorCacheService extends MonitoringStorage
+class MonitorCacheService extends SimpleMonitoringStorage
 {
     /**
      * @param DeliveryExecutionCreated $event
@@ -129,7 +128,7 @@ class MonitorCacheService extends MonitoringStorage
      */
     public function testStateChanged(TestChangedEvent $event)
     {
-        $deliveryExecution = ServiceProxy::singleton()->getDeliveryExecution($event->getServiceCallId());
+        $deliveryExecution = $this->getServiceLocator()->get(DeliveryExecutionService::SERVICE_ID)->getDeliveryExecution($event->getServiceCallId());
 
         $data = $this->createMonitoringData($deliveryExecution);
 

--- a/model/monitorCache/implementation/MonitoringStorage.php
+++ b/model/monitorCache/implementation/MonitoringStorage.php
@@ -71,6 +71,8 @@ use oat\taoProctoring\model\execution\DeliveryExecution as ProctoredDeliveryExec
  *
  * @package oat\taoProctoring\model
  * @author Aleh Hutnikau <hutnikau@1pt.com>
+ *
+ * @deprecated 
  */
 class MonitoringStorage extends ConfigurableService implements DeliveryMonitoringService
 {

--- a/model/monitorCache/implementation/SimpleMonitoringStorage.php
+++ b/model/monitorCache/implementation/SimpleMonitoringStorage.php
@@ -688,9 +688,9 @@ class SimpleMonitoringStorage extends ConfigurableService implements DeliveryMon
                     $whereClause .= sprintf(' JSON_EXTRACT(t.%s, \'$.%s\') %s ', self::COLUMN_EXTRA_DATA, trim($key), $op);
                 } else {
                     $whereClause .= sprintf(' t.%s -> \'%s\' %s ', self::COLUMN_EXTRA_DATA, trim($key), $op);
-                    $value = is_array($value) ? $value : [$value];
-                    $value = array_map('json_encode', $value);
                 }
+                $value = is_array($value) ? $value : [$value];
+                $value = array_map('json_encode', $value);
             }
 
             if(is_array($value)){

--- a/model/monitorCache/implementation/SimpleMonitoringStorage.php
+++ b/model/monitorCache/implementation/SimpleMonitoringStorage.php
@@ -1,0 +1,734 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoProctoring\model\monitorCache\implementation;
+
+use common_exception_NotFound;
+use common_Logger;
+use common_persistence_SqlPersistence;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Exception;
+use oat\generis\persistence\PersistenceManager;
+use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
+use oat\taoDelivery\model\execution\ServiceProxy;
+use oat\taoDelivery\model\execution\Delete\DeliveryExecutionDeleteRequest;
+use oat\taoProctoring\helpers\DeliveryHelper;
+use oat\taoProctoring\model\monitorCache\DeliveryMonitoringService;
+use oat\taoProctoring\model\monitorCache\DeliveryMonitoringData as DeliveryMonitoringDataInterface;
+use oat\oatbox\service\ConfigurableService;
+use oat\generis\model\OntologyAwareTrait;
+use oat\taoProctoring\model\execution\DeliveryExecution as ProctoredDeliveryExecution;
+use PDO;
+use PDOException;
+
+class SimpleMonitoringStorage extends ConfigurableService implements DeliveryMonitoringService
+{
+    use OntologyAwareTrait;
+
+    const OPTION_PERSISTENCE = 'persistence';
+    const OPTION_USE_UPDATE_MULTIPLE = 'use_update_multiple';
+
+    const OPTION_PRIMARY_COLUMNS = 'primary_columns';
+
+    const TABLE_NAME = 'delivery_monitoring';
+
+    const COLUMN_ID = DeliveryMonitoringService::DELIVERY_EXECUTION_ID;
+    const COLUMN_DELIVERY_EXECUTION_ID = DeliveryMonitoringService::DELIVERY_EXECUTION_ID;
+    const COLUMN_STATUS = DeliveryMonitoringService::STATUS;
+    const COLUMN_CURRENT_ASSESSMENT_ITEM = DeliveryMonitoringService::CURRENT_ASSESSMENT_ITEM;
+    const COLUMN_TEST_TAKER = DeliveryMonitoringService::TEST_TAKER;
+    const COLUMN_TEST_TAKER_FIRST_NAME = DeliveryMonitoringService::TEST_TAKER_FIRST_NAME;
+    const COLUMN_TEST_TAKER_LAST_NAME = DeliveryMonitoringService::TEST_TAKER_LAST_NAME;
+    const COLUMN_AUTHORIZED_BY = DeliveryMonitoringService::AUTHORIZED_BY;
+    const COLUMN_START_TIME = DeliveryMonitoringService::START_TIME;
+    const COLUMN_END_TIME = DeliveryMonitoringService::END_TIME;
+    const COLUMN_REMAINING_TIME = DeliveryMonitoringService::REMAINING_TIME;
+    const COLUMN_EXTRA_TIME = DeliveryMonitoringService::EXTRA_TIME;
+    const COLUMN_CONSUMED_EXTRA_TIME = DeliveryMonitoringService::CONSUMED_EXTRA_TIME;
+
+    const DEFAULT_SORT_COLUMN = self::COLUMN_ID;
+    const DEFAULT_SORT_ORDER = 'ASC';
+    const DEFAULT_SORT_TYPE = 'string';
+
+    private $joins = [];
+    private $queryParams = [];
+
+    /**
+     * @param DeliveryExecutionInterface $deliveryExecution
+     * @param $data
+     * @return DeliveryMonitoringData
+     * @throws common_exception_NotFound
+     */
+    public function createMonitoringData(DeliveryExecutionInterface $deliveryExecution, $data = [])
+    {
+        $data = array_merge([
+            DeliveryMonitoringService::DELIVERY_EXECUTION_ID => $deliveryExecution->getIdentifier(),
+        ], $data);
+
+        if (!array_key_exists(DeliveryMonitoringService::STATUS, $data)) {
+            $data[DeliveryMonitoringService::STATUS] = $deliveryExecution->getState()->getUri();
+        }
+
+        // @todo data object should not use ServiceLocator
+        $monitoringData = new DeliveryMonitoringData($deliveryExecution, $data);
+        $this->propagate($monitoringData);
+
+        return $monitoringData;
+    }
+
+    /**
+     * @param DeliveryExecutionInterface $deliveryExecution
+     * @return array|DeliveryMonitoringData
+     * @throws common_exception_NotFound
+     */
+    public function getData(DeliveryExecutionInterface $deliveryExecution): array
+    {
+        return $this->createMonitoringData(
+            $deliveryExecution,
+            $this->loadData($deliveryExecution->getIdentifier())
+        );
+    }
+
+    /**
+     * @param array $criteria
+     * @param array $options
+     * @return DeliveryMonitoringData[]
+     * @throws common_exception_NotFound
+     */
+    public function find(array $criteria = [], array $options = []): array
+    {
+        $result = [];
+        $this->joins = [];
+        $this->queryParams = [];
+        $selectColumns = $this->getPrimaryColumns();
+        $groupColumns = [];
+        $defaultOptions = [
+            'order' => join(' ', [static::DEFAULT_SORT_COLUMN, static::DEFAULT_SORT_ORDER, static::DEFAULT_SORT_TYPE]),
+            'offset' => 0,
+            'asArray' => false
+        ];
+        $options = array_merge($defaultOptions, $options);
+
+        $options['order'] = $this->prepareOrderStmt($options['order']);
+        $fromClause = "FROM " . self::TABLE_NAME . " t ";
+
+        $whereClause = $this->prepareCondition($criteria, $this->queryParams, $selectClause);
+        if ($whereClause !== '') {
+            $whereClause = 'WHERE ' . $whereClause;
+        }
+
+        $selectClause = "SELECT " . implode(','.PHP_EOL, $selectColumns) . PHP_EOL;
+
+        $sql = $selectClause . ' ' . $fromClause . PHP_EOL .
+            implode(PHP_EOL, $this->joins) . PHP_EOL .
+            $whereClause . PHP_EOL;
+
+        if (!empty($groupColumns)) {
+            if (!in_array('t.delivery_execution_id', $groupColumns)) {
+                $groupColumns[] = 't.delivery_execution_id';
+            }
+            $sql .= 'GROUP BY ' . implode(',', $groupColumns) . PHP_EOL;
+        }
+
+        $sql .= "ORDER BY " . $options['order'];
+
+        if (isset($options['limit']))  {
+            $sql = $this->getPersistence()->getPlatForm()->limitStatement($sql, $options['limit'], $options['offset']);
+        }
+
+        $stmt = $this->getPersistence()->query($sql, $this->queryParams);
+
+        $data = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        if ($options['asArray']) {
+            $result = $data;
+        } else {
+            foreach($data as $row) {
+                $extraData = [];
+                if (isset($row['extra_data'])) {
+                    $decodedExtraData = json_decode($row['extra_data']);
+                    if (json_last_error() === JSON_ERROR_NONE) {
+                        $extraData = $decodedExtraData;
+                    }
+                }
+                $row['extra_data'] = $extraData;
+
+                $deliveryExecution = ServiceProxy::singleton()->getDeliveryExecution($row[self::COLUMN_DELIVERY_EXECUTION_ID]);
+                $result[] = $this->createMonitoringData($deliveryExecution, $row);
+            }
+        }
+
+        return $result;
+    }
+
+    public function count(array $criteria = []): int
+    {
+        $this->joins = [];
+        $this->queryParams = [];
+
+        $selectClause = "select COUNT(*) FROM (SELECT t.delivery_execution_id ";
+        $fromClause = "FROM " . self::TABLE_NAME . " t ";
+        $whereClause = $this->prepareCondition($criteria, $this->queryParams, $selectClause);
+        if ($whereClause !== '') {
+            $whereClause = 'WHERE ' . $whereClause;
+        }
+        $sql = $selectClause . $fromClause . PHP_EOL .
+            implode(PHP_EOL, $this->joins) . PHP_EOL .
+            $whereClause . PHP_EOL .
+            'GROUP BY t.' . self::DELIVERY_EXECUTION_ID . ') as count_q';
+
+        $stmt = $this->getPersistence()->query($sql, $this->queryParams);
+        $result = $stmt->fetch(PDO::FETCH_BOTH);
+        return intval($result[0]);
+    }
+
+    /**
+     * @param DeliveryMonitoringDataInterface $deliveryMonitoring
+     * @return bool|mixed
+     * @throws Exception
+     */
+    public function save(DeliveryMonitoringDataInterface $deliveryMonitoring): bool
+    {
+        $result = false;
+        if ($deliveryMonitoring->validate()) {
+            try {
+                // we should be ready for unique violation error when the calling side calls
+                // save() instead of partialSave()
+                $result = $this->create($deliveryMonitoring);
+            } catch (PDOException $e) {
+                // when the PDO implementation of RDS is used as a persistence
+                // unfortunately the exception is very broad so it can cover more than intended cases
+            } catch (UniqueConstraintViolationException $e) {
+                // when the DBAL implementation of RDS is used as a persistence
+            }
+            if (!$result) {
+                $this->update($deliveryMonitoring);
+            }
+
+            $result = true;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param DeliveryMonitoringDataInterface $deliveryMonitoring
+     * @return bool
+     * @throws Exception
+     */
+    public function partialSave(DeliveryMonitoringDataInterface $deliveryMonitoring): bool
+    {
+        $result = false;
+        if ($deliveryMonitoring->validate()) {
+            $rowsUpdated = $this->update($deliveryMonitoring);
+            if ($rowsUpdated === 0) {
+                // doesn't mean an error for sure, cause persistence may return the number of rows actually changed,
+                // and not the number of rows matched by the where clause.
+                // So just in case try to create without fallback
+                try {
+                    $this->create($deliveryMonitoring);
+                } catch (PDOException $e) {
+                    // when the PDO implementation of RDS is used as a persistence
+                } catch (UniqueConstraintViolationException $e) {
+                    // when the DBAL implementation of RDS is used as a persistence
+                }
+            }
+
+            $result = true;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param DeliveryMonitoringDataInterface $deliveryMonitoring
+     * @return boolean
+     */
+    public function delete(DeliveryMonitoringDataInterface $deliveryMonitoring): bool
+    {
+        $data = $deliveryMonitoring->get();
+
+        $sql = sprintf('DELETE FROM %s WHERE %s = ?', self::TABLE_NAME, self::COLUMN_DELIVERY_EXECUTION_ID);
+
+        return $this->getPersistence()->exec($sql, [$data[self::COLUMN_DELIVERY_EXECUTION_ID]]) === 1;
+    }
+
+    /**
+     * Load data instead of searching
+     *
+     * @param string $deliveryExecutionId
+     * @return array
+     */
+    private function loadData(string $deliveryExecutionId): array
+    {
+        $qb = $this->getQueryBuilder();
+        $qb->select('*')
+            ->from(self::TABLE_NAME)
+            ->where(self::DELIVERY_EXECUTION_ID.'= :id')
+            ->setParameter('id', $deliveryExecutionId);
+
+        $data = $qb->execute()->fetch(PDO::FETCH_ASSOC);
+
+        if ($data === false) {
+            $data = [];
+        } else {
+            $extraData = json_decode($data['extra_data']);
+            if (json_last_error() === JSON_ERROR_NONE) {
+                $data = array_merge($data, $extraData);
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Create new record
+     * @param DeliveryMonitoringDataInterface $deliveryMonitoring
+     * @return boolean whether data is saved
+     * @throws Exception
+     */
+    private function create(DeliveryMonitoringDataInterface $deliveryMonitoring): bool
+    {
+        $data = $deliveryMonitoring->get();
+
+        $primaryTableData = $this->extractPrimaryData($data);
+
+        $extraData = $this->extractKvData($data);
+
+        $types['extra_data'] = 'jsonb';
+        $primaryTableData['extra_data'] = json_encode($extraData);
+
+        return $this->getPersistence()->insert(self::TABLE_NAME, $primaryTableData, $types) === 1;
+    }
+
+    /**
+     * Update existing record
+     * @param DeliveryMonitoringDataInterface $deliveryMonitoring
+     * @return boolean whether data is saved
+     */
+    private function update(DeliveryMonitoringDataInterface $deliveryMonitoring)
+    {
+        $params = [':delivery_execution_id' => $deliveryMonitoring->get()[self::COLUMN_DELIVERY_EXECUTION_ID]];
+
+        $data = $deliveryMonitoring->get();
+        $extraData = $this->extractKvData($data);
+
+        $primaryTableData = $this->extractPrimaryData($data);
+
+        unset($primaryTableData['delivery_execution_id']);
+        $setClauses = [];
+        foreach ($primaryTableData as $dataKey => $dataValue) {
+            $setClauses[] = sprintf('%s = :%s', $dataKey, $dataKey);
+            $params[sprintf(':%s', $dataKey)] = $dataValue;
+        }
+
+        $setExtraDataClauses = [];
+
+        foreach ($extraData as $extraDataKey => $extraDataValue) {
+            $setExtraDataClauses[] = sprintf('jsonb_build_object(\'%s\', \'%s\')', $extraDataKey, $extraDataValue);
+        }
+
+        if (!empty($setExtraDataClauses)) {
+            $setClauses[] = 'extra_data = extra_data || ' . implode(' || ', $setExtraDataClauses);
+        }
+
+        $setClause = implode(', ', $setClauses);
+
+        $sql = "UPDATE " . self::TABLE_NAME . " SET $setClause
+        WHERE " . self::COLUMN_DELIVERY_EXECUTION_ID . ' = :delivery_execution_id';
+
+        return $this->getPersistence()->exec($sql, $params);
+    }
+
+    /**
+     * @param $order
+     * @return string
+     */
+    private function prepareOrderStmt($order): string
+    {
+        $order = explode(',', $order);
+        $result = [];
+        $primaryTableColumns = $this->getPrimaryColumns();
+        foreach ($order as $ruleNum => $orderRule) {
+            preg_match('/([a-zA-Z_][a-zA-Z0-9_]*)\s?(asc|desc)?\s?(string|numeric)?/i', $orderRule, $ruleParts);
+
+            if (!in_array($ruleParts[1], $primaryTableColumns)) {
+                $colName = $ruleParts[1];
+                $this->queryParams[] = $colName;
+            } else {
+                $sortingColumn = $ruleParts[1];
+            }
+
+            $result[] = isset($ruleParts[3]) && $ruleParts[3] === 'numeric'
+                ? sprintf("cast(nullif(%s, '') as decimal) %s", $sortingColumn, $ruleParts[2])
+                : sprintf('%s %s', $sortingColumn, isset($ruleParts[2]) ? $ruleParts[2] : 'ASC');
+        }
+
+        return implode(', ', $result);
+    }
+
+    /**
+     * @return common_persistence_SqlPersistence
+     */
+    public function getPersistence()
+    {
+        return $this->getServiceLocator()
+            ->get(PersistenceManager::SERVICE_ID)
+            ->getPersistenceById($this->getOption(self::OPTION_PERSISTENCE));
+    }
+
+    /**
+     * @param string $sortBy
+     * @return string
+     */
+    public static function getSortByColumn($sortBy)
+    {
+        $map = array_merge([
+            'firstname' => self::COLUMN_TEST_TAKER_FIRST_NAME,
+            'lastname' => self::TEST_TAKER_LAST_NAME,
+            'delivery' => self::DELIVERY_NAME,
+            'status' => self::STATUS,
+            'connectivity' => self::CONNECTIVITY,
+        ],
+            array_combine(array_map(function ($property) {
+                return strtolower($property['id']);
+            }, DeliveryHelper::getExtraFields()), array_map(function ($property) {
+                return $property['id'];
+            }, DeliveryHelper::getExtraFields())));
+
+        return array_key_exists(strtolower($sortBy), $map) ? $map[strtolower($sortBy)] : self::DEFAULT_SORT_COLUMN;
+    }
+
+    /**
+     * @todo extract this method to another service with statistic responsabilities
+     *
+     * @return mixed
+     */
+    public function getCountOfStatistics()
+    {
+        $groupedQueryBuilder = $this->getQueryBuilder();
+        $groupedQueryBuilder->select('delivery_monitoring.delivery_id');
+        $groupedQueryBuilder->from('delivery_monitoring');
+        $groupedQueryBuilder->groupBy('delivery_monitoring.delivery_id');
+        $groupedSql = $groupedQueryBuilder->getSQL();
+
+        $countQueryBuilder = $this->getQueryBuilder();
+        $countQueryBuilder->select('count(grouped.delivery_id)');
+        $countQueryBuilder->from('('.$groupedSql.')', 'grouped');
+        $stmt = $this->getPersistence()->query($countQueryBuilder->getSQL());
+        return $stmt->fetch(PDO::FETCH_COLUMN);
+    }
+
+    /**
+     * @todo extract this method to another service with statistic responsabilities
+     * @todo query of 150 lines, erf
+     *
+     * @param int $limit
+     * @param int $offset
+     * @param string $orderby
+     * @param string $orderdir
+     * @return mixed|void
+     */
+    public function getStatusesStatistic($limit = 10, $offset = 0, $orderby = 'label', $orderdir = 'asc')
+    {
+        $statusesList = [
+            $this->getResource(ProctoredDeliveryExecution::STATE_ACTIVE),
+            $this->getResource(ProctoredDeliveryExecution::STATE_AUTHORIZED),
+            $this->getResource(ProctoredDeliveryExecution::STATE_AWAITING),
+            $this->getResource(ProctoredDeliveryExecution::STATE_CANCELED),
+            $this->getResource(ProctoredDeliveryExecution::STATE_FINISHED),
+            $this->getResource(ProctoredDeliveryExecution::STATE_PAUSED),
+            $this->getResource(ProctoredDeliveryExecution::STATE_TERMINATED)
+        ];
+        $statusesMap = [];
+        foreach ($statusesList as $status) {
+            $statusesMap[$status->getLabel()] = $status->getUri();
+        }
+
+        $paramsValues = [];
+        $limitQueryBuilder = $this->getQueryBuilder();
+        $limitQueryBuilder->select('limit_q.delivery_id');
+        $limitQueryBuilder->groupBy('limit_q.delivery_id');
+
+        if (isset($statusesMap[$orderby])) {
+            $innerQueryBuilder = $this->getQueryBuilder();
+            $innerQueryBuilder->select('delivery_monitoring.delivery_id');
+            $innerQueryBuilder->addSelect('COALESCE( order_join.order_status, 0 ) as order_val');
+            $innerQueryBuilder->from('delivery_monitoring');
+
+            $statusBuilder = $this->getQueryBuilder();
+            $statusBuilder->select('status_d_m.delivery_id, count(status_d_m.status) order_status');
+            $statusBuilder->from('delivery_monitoring', 'status_d_m');
+            $statusBuilder->where('status_d_m.status = :status_order');
+            $paramsValues[':status_order'] =  $statusesMap[$orderby];
+            $statusBuilder->groupBy('status_d_m.delivery_id');
+            $statusSql = $statusBuilder->getSQL();
+
+            $innerQueryBuilder->leftJoin(
+                'delivery_monitoring',
+                '('.$statusSql.')',
+                'order_join',
+                'order_join.delivery_id=delivery_monitoring.delivery_id'
+            );
+            $innerQueryBuilder->groupBy('delivery_monitoring.delivery_id, order_val');
+            $innerQueryBuilder->orderBy('order_val', $orderdir);
+
+            if ($limit) {
+                $innerQueryBuilder->setMaxResults($limit);
+            }
+            $innerQueryBuilder->setFirstResult($offset);
+
+            $innerSql = $innerQueryBuilder->getSQL();
+            $limitQueryBuilder->from('('.$innerSql.')', 'limit_q');
+            $limitQueryBuilder->addGroupBy('limit_q.order_val');
+            $limitQueryBuilder->orderBy('order_val', $orderdir);
+        } else if($orderby == 'label') {
+            $limitQueryBuilder->from('delivery_monitoring', 'limit_q');
+            $limitQueryBuilder->addSelect('limit_q.delivery_name');
+            $limitQueryBuilder->addGroupBy('limit_q.delivery_name');
+            $limitQueryBuilder->orderBy('limit_q.delivery_name', $orderdir);
+            if ($limit) {
+                $limitQueryBuilder->setMaxResults($limit);
+            }
+            $limitQueryBuilder->setFirstResult($offset);
+        } else {
+            $limitQueryBuilder->from('delivery_monitoring', 'limit_q');
+            $limitQueryBuilder->addSelect('max(limit_q.start_time) as max_start_time');
+            $limitQueryBuilder->orderBy('max_start_time', $orderdir);
+            if ($limit) {
+                $limitQueryBuilder->setMaxResults($limit);
+            }
+            $limitQueryBuilder->setFirstResult($offset);
+        }
+        $limitQueryBuilder->andWhere('limit_q.delivery_id IS NOT NULL');
+        $limitSql = $limitQueryBuilder->getSQL();
+        $stmtLimit = $this->getPersistence()->query($limitSql, $paramsValues);
+        $dataLimit = $stmtLimit->fetchAll(PDO::FETCH_COLUMN);
+
+
+        $queryBuilder = $this->getQueryBuilder();
+        $conn = $queryBuilder->getConnection();
+        $queryBuilder->select('delivery_m.delivery_id, delivery_m.delivery_name');
+
+        foreach ($statusesMap as $label => $statusUri) {
+            $queryBuilder->addSelect('count('.$conn->quoteIdentifier('s_'.$label).'.status) as ' . $conn->quoteIdentifier($label));
+        }
+
+        $queryBuilder->addSelect('max('.$conn->quoteIdentifier('last_launch').'.start_time) as ' . $conn->quoteIdentifier(__('Last launch')));
+
+        $queryBuilder->from(self::TABLE_NAME, 'delivery_m');
+
+        $paramsValues = [];
+        $statusNum = 0;
+        foreach ($statusesMap as $label => $statusUri) {
+            $queryBuilder->leftJoin(
+                'delivery_m',
+                self::TABLE_NAME,
+                $conn->quoteIdentifier('s_'.$label),
+                'delivery_m.delivery_execution_id='.$conn->quoteIdentifier('s_'.$label).'.delivery_execution_id and '
+                .$conn->quoteIdentifier('s_'.$label).'.status = :status_uri_'.$statusNum
+            );
+            $paramsValues[':status_uri_'.$statusNum] = $statusUri;
+            $statusNum++;
+        }
+        $queryBuilder->leftJoin(
+            'delivery_m',
+            self::TABLE_NAME,
+            $conn->quoteIdentifier('last_launch'),
+            'delivery_m.delivery_execution_id='.$conn->quoteIdentifier('last_launch').'.delivery_execution_id'
+        );
+
+        if ($dataLimit) {
+            $placeHolders = [];
+            foreach ($dataLimit as $index => $value) {
+                $key = ':in_condition_' . $index;
+                $placeHolders[] = $key;
+                $paramsValues[$key] = $value;
+            }
+            $placeHolders = implode(',', $placeHolders);
+            $queryBuilder->where("delivery_m.delivery_id IN ($placeHolders)");
+        }
+
+        $queryBuilder->groupBy('delivery_m.delivery_id, delivery_m.delivery_name');
+
+        foreach ($statusesMap as $label => $statusUri) {
+            $queryBuilder->addGroupBy($conn->quoteIdentifier('s_'.$label).'.status');
+        }
+
+        $outerQueryBuilder = $this->getQueryBuilder();
+
+        $outerQueryBuilder->select('delivery_name as label, delivery_id');
+
+        foreach ($statusesMap as $label => $statusUri) {
+            $outerQueryBuilder->addSelect('sum('.$conn->quoteIdentifier($label).') as ' . $conn->quoteIdentifier($label));
+        }
+        $outerQueryBuilder->addSelect('max('.$conn->quoteIdentifier(__('Last launch')).') as ' .  $conn->quoteIdentifier(__('Last launch')));
+        $outerQueryBuilder->from('('.$queryBuilder->getSQL().')', 'delivery_statuses');
+        $outerQueryBuilder->groupBy('delivery_id, label');
+        $outerQueryBuilder->orderBy($conn->quoteIdentifier($orderby), $orderdir);
+
+        $sql = $outerQueryBuilder->getSQL();
+
+        $stmt = $this->getPersistence()->query($sql, $paramsValues);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function deleteDeliveryExecutionData(DeliveryExecutionDeleteRequest $request): bool
+    {
+        return $this->delete(
+            $this->getData($request->getDeliveryExecution())
+        );
+    }
+
+    /**
+     * Get list of table column names
+     * @return array
+     */
+    private function getPrimaryColumns()
+    {
+        return $this->getOption(self::OPTION_PRIMARY_COLUMNS);
+    }
+
+    /**
+     * @todo cast data to object
+     * @param array $data
+     * @return array
+     */
+    private function extractPrimaryData(array $data)
+    {
+        $result = [];
+        $primaryTableCols = $this->getPrimaryColumns();
+        foreach ($primaryTableCols as $primaryTableCol) {
+            if (isset($data[$primaryTableCol])) {
+                $result[$primaryTableCol] = $data[$primaryTableCol];
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * @param array $data
+     * @return array
+     */
+    private function extractKvData(array $data)
+    {
+        $result = [];
+        $primaryTableCols = $this->getPrimaryColumns();
+        foreach ($data as $key => $val) {
+            if (!in_array($key, $primaryTableCols)) {
+                $result[$key] = $val;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param $condition
+     * @param $parameters
+     * @param $selectClause
+     * @return string
+     */
+    private function prepareCondition($condition, &$parameters, &$selectClause)
+    {
+        $whereClause = '';
+
+        //if condition is [ [ key => val ] ] then flatten to [ key => val ]
+        if (is_array($condition) && count($condition) === 1 && is_array(current($condition)) && gettype(array_keys($condition)[0]) == 'integer' ) {
+             $condition = current($condition);
+        }
+
+        if (is_string($condition) && in_array(mb_strtoupper($condition), ['OR', 'AND'])) {
+            $whereClause .= " $condition ";
+        } else if (is_array($condition) && count($condition) > 1) {
+            $whereClause .=  '(';
+            $previousCondition = null;
+            foreach ($condition as $subCondition) {
+                if (is_array($subCondition) && is_array($previousCondition)) {
+                    $whereClause .= 'AND';
+                }
+                $whereClause .=  $this->prepareCondition($subCondition, $parameters, $selectClause);
+                $previousCondition = $subCondition;
+            }
+            $whereClause .=  ')';
+        } else if (is_array($condition) && count($condition) === 1) {
+            $primaryColumns = $this->getPrimaryColumns();
+            $key = array_keys($condition)[0];
+            $value = $condition[$key];
+            $toLower = false;
+
+            if ($value === null) {
+                $op = 'IS NULL';
+            } elseif(is_array($value)){
+                $op = 'IN (' . join(',', array_map(function(){ return '?'; }, $value)) . ')';
+            } elseif (preg_match('/^(?:\s*(<>|<=|>=|<|>|=|LIKE|ILIKE|NOT\sLIKE|NOT\sILIKE))?(.*)$/', $value, $matches)) {
+                if (!empty($matches[1]) && preg_grep('/' . $matches[1] .'/i', ['like','ilike'])) {
+                    $toLower = true;
+                    $op = 'LIKE';
+                } elseif (!empty($matches[1]) && preg_grep('/' . $matches[1] .'/i', ['not like','not ilike'])) {
+                    $toLower = true;
+                    $op = 'NOT LIKE';
+                } else {
+                    $op = $matches[1] ? $matches[1] : '=';
+                }
+                $op .= ' ? ';
+                $value = $toLower ? strtolower($matches[2]) : $matches[2];
+            }
+
+            /** @todo search on extra column */
+            if (in_array($key, $primaryColumns)) {
+                $whereClause .= $toLower ? " LOWER(t.$key) " : " t.$key ";
+                $whereClause .= $op;
+            } else {
+                common_Logger::e('TEST');
+
+
+                // TODO FIXME
+                $whereClause .= ' "extra_data"::json->>\'' . trim($key) . '\'=\'?\'';
+//                $joinNum = count($this->joins);
+//                $whereClause .= " (kv_t_$joinNum.monitoring_key = ? AND ";
+//                $whereClause .= $toLower ? "LOWER(kv_t_$joinNum.monitoring_value)" : "kv_t_$joinNum.monitoring_value";
+//                $whereClause .= " $op) ";
+
+//                $this->joins[] = "LEFT JOIN " . self::KV_TABLE_NAME . " kv_t_$joinNum ON kv_t_$joinNum." . self::KV_COLUMN_PARENT_ID . " = t." . self::COLUMN_DELIVERY_EXECUTION_ID;
+                $parameters[] = trim($key);
+            }
+
+            if(is_array($value)){
+               $parameters = array_merge($parameters, $value);
+            } else if ($value !== null) {
+                $parameters[] = trim($value);
+            }
+        }
+        return $whereClause;
+    }
+
+    /**
+     * @return QueryBuilder
+     */
+    private function getQueryBuilder(): QueryBuilder
+    {
+        return $this->getPersistence()->getPlatForm()->getQueryBuilder();
+    }
+}

--- a/model/monitorCache/implementation/SimpleMonitoringStorage.php
+++ b/model/monitorCache/implementation/SimpleMonitoringStorage.php
@@ -569,8 +569,12 @@ class SimpleMonitoringStorage extends ConfigurableService implements DeliveryMon
                 );
             } else {
                 $setClauses[] = sprintf(
-                    '%s = %s || %s',
-                    self::COLUMN_EXTRA_DATA, self::COLUMN_EXTRA_DATA, implode(' || ', $setExtraDataClauses)
+                    '%s = CASE WHEN %s IS NULL THEN %s ELSE %s || %s END',
+                    self::COLUMN_EXTRA_DATA,
+                    self::COLUMN_EXTRA_DATA,
+                    implode(' || ', $setExtraDataClauses),
+                    self::COLUMN_EXTRA_DATA,
+                    implode(' || ', $setExtraDataClauses)
                 );
             }
         }

--- a/model/monitorCache/implementation/SimpleMonitoringStorage.php
+++ b/model/monitorCache/implementation/SimpleMonitoringStorage.php
@@ -161,7 +161,8 @@ class SimpleMonitoringStorage extends ConfigurableService implements DeliveryMon
                     $extraData = $decodedExtraData;
                 }
             }
-            $row[self::COLUMN_EXTRA_DATA] = $extraData;
+            unset($row[self::COLUMN_EXTRA_DATA]);
+            $row = array_merge($row, $extraData);
 
             if (!$options['asArray']) {
                 $deliveryExecution = ServiceProxy::singleton()->getDeliveryExecution($row[self::COLUMN_DELIVERY_EXECUTION_ID]);
@@ -499,6 +500,7 @@ class SimpleMonitoringStorage extends ConfigurableService implements DeliveryMon
                     $data = array_merge($data, $extraData);
                 }
             }
+            unset($data[self::COLUMN_EXTRA_DATA]);
         }
 
         return $data;

--- a/scripts/tools/MonitoringExtraFieldMigration.php
+++ b/scripts/tools/MonitoringExtraFieldMigration.php
@@ -15,10 +15,11 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2018 (original work) Open Assessment Technologies SA;
- *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
  *
  */
+
+declare(strict_types=1);
 
 namespace oat\taoProctoring\scripts\tools;
 
@@ -26,74 +27,78 @@ use oat\oatbox\extension\script\ScriptAction;
 use common_report_Report as Report;
 use oat\taoProctoring\model\monitorCache\DeliveryMonitoringService;
 use oat\taoProctoring\model\monitorCache\implementation\MonitoringStorage;
+use oat\taoProctoring\model\monitorCache\implementation\SimpleMonitoringStorage;
+use oat\taoProctoring\scripts\install\db\DbSetup;
+use PDO;
 
-
-/**
- * @deprecated
- */
-class KvMonitoringMigration extends ScriptAction
+class MonitoringExtraFieldMigration extends ScriptAction
 {
     protected function provideOptions()
     {
-        return [
-            'fields' => [
-                'prefix' => 'f',
-                'longPrefix' => 'fields',
-                'required' => true,
-                'description' => 'A string contains coma separated list of target fields'
-            ],
-
-            'dataLength' => [
-                'prefix' => 'l',
-                'longPrefix' => 'dataLength',
-                'required' => false,
-                'description' => 'Data length. If present new column(s) will have type VARCHAR($length), otherwise - TEXT column will be created'
-            ],
-
-            'deleteKV' => [
-                'prefix' => 'd',
-                'longPrefix' => 'deleteKV',
-                'defaultValue' => 0,
-                'cast' => 'integer',
-                'required' => false,
-                'description' => 'Indicate whether or not records from KV strorage should be removed'
-            ],
-
-            'strictMode' => [
-                'prefix' => 's',
-                'longPrefix' => 'strictMode',
-                'defaultValue' => 1,
-                'cast' => 'integer',
-                'required' => false,
-                'description' => 'Allow to skip creation of already existing in RDBS columns, should help resuming interrupted migrations '
-            ],
-
-            'persistConfig' => [
-                'flag' => true,
-                'prefix' => 'pc',
-                'longPrefix' => 'persistConfig',
-                'defaultValue' => 1,
-                'description' => 'Indicate whether or not changes in config should be recorded. Please note that applies to the current instance only and changes MUST be distributed across all of them'
-            ],
-
-            'resume' => [
-                'flag' => true,
-                'prefix' => 'r',
-                'longPrefix' => 'resume',
-                'defaultValue' => 1,
-                'description' => 'Indicate whether or not changes processing should be resumed from the last processed frame'
-            ],
-
-            'chunkSize' => [
-                'prefix' => 'c',
-                'defaultValue' => 100,
-                'longPrefix' => 'chunk-size',
-                'cast' => 'integer',
-                'required' => false,
-                'description' => 'Specifies delivery executions amount for processing (chunk size) per iteration for migration'
-            ],
-        ];
+        return [];
     }
+
+//    protected function provideOptions()
+//    {
+//        return [
+//            'fields' => [
+//                'prefix' => 'f',
+//                'longPrefix' => 'fields',
+//                'required' => true,
+//                'description' => 'A string contains coma separated list of target fields'
+//            ],
+//
+//            'dataLength' => [
+//                'prefix' => 'l',
+//                'longPrefix' => 'dataLength',
+//                'required' => false,
+//                'description' => 'Data length. If present new column(s) will have type VARCHAR($length), otherwise - TEXT column will be created'
+//            ],
+//
+//            'deleteKV' => [
+//                'prefix' => 'd',
+//                'longPrefix' => 'deleteKV',
+//                'defaultValue' => 0,
+//                'cast' => 'integer',
+//                'required' => false,
+//                'description' => 'Indicate whether or not records from KV strorage should be removed'
+//            ],
+//
+//            'strictMode' => [
+//                'prefix' => 's',
+//                'longPrefix' => 'strictMode',
+//                'defaultValue' => 1,
+//                'cast' => 'integer',
+//                'required' => false,
+//                'description' => 'Allow to skip creation of already existing in RDBS columns, should help resuming interrupted migrations '
+//            ],
+//
+//            'persistConfig' => [
+//                'flag' => true,
+//                'prefix' => 'pc',
+//                'longPrefix' => 'persistConfig',
+//                'defaultValue' => 1,
+//                'description' => 'Indicate whether or not changes in config should be recorded. Please note that applies to the current instance only and changes MUST be distributed across all of them'
+//            ],
+//
+//            'resume' => [
+//                'flag' => true,
+//                'prefix' => 'r',
+//                'longPrefix' => 'resume',
+//                'defaultValue' => 1,
+//                'description' => 'Indicate whether or not changes processing should be resumed from the last processed frame'
+//            ],
+//
+//            'chunkSize' => [
+//                'prefix' => 'c',
+//                'defaultValue' => 100,
+//                'longPrefix' => 'chunk-size',
+//                'cast' => 'integer',
+//                'required' => false,
+//                'description' => 'Specifies delivery executions amount for processing (chunk size) per iteration for migration'
+//            ],
+//        ];
+//    }
 
     protected function provideDescription()
     {
@@ -111,6 +116,83 @@ class KvMonitoringMigration extends ScriptAction
      */
     protected function run()
     {
+        // check if service is already configured to use JSON column and if column `extra_field` exists
+        $monitoringService = $this->getServiceManager()->get(DeliveryMonitoringService::SERVICE_ID);
+        if (!$monitoringService instanceof SimpleMonitoringStorage) {
+            throw new \Exception('DeliveryMonitoringService is not implementing SimpleMonitoringStorage. Migration aborted');
+        }
+
+        $table = $monitoringService
+            ->getPersistence()
+            ->getDriver()
+            ->getSchemaManager()
+            ->createSchema()
+            ->getTable(SimpleMonitoringStorage::TABLE_NAME);
+        if (!$table->hasColumn(SimpleMonitoringStorage::COLUMN_EXTRA_DATA)) {
+            throw new \Exception(sprintf('Column %s does not exist. Migration aborted', SimpleMonitoringStorage::COLUMN_EXTRA_DATA));
+        }
+
+        //option
+        $chunkSize = 100;
+        $count = $monitoringService->count();
+        $chunk = ceil($count / $chunkSize);
+
+        $removed = $updated = 0;
+
+        echo sprintf('%s delivery executions found', $count) . PHP_EOL;
+
+        for ($i = 0 ; $i < $chunk ; $i++) {
+            $options = [
+                'limit' => $chunkSize,
+                'offset' => 0,
+            ];
+
+            $deliveryExecutions = $monitoringService->find([], $options);
+            echo sprintf('%s delivery executions fetched', count($deliveryExecutions)) . PHP_EOL;
+
+            foreach ($deliveryExecutions as $deliveryExecution) {
+
+                $deliveryExecutionId = $deliveryExecution->get()[DeliveryMonitoringService::DELIVERY_EXECUTION_ID];
+
+                $sql = 'SELECT monitoring_key, monitoring_value FROM kv_delivery_monitoring WHERE parent_id = ?';
+
+                $stmt = $monitoringService->getPersistence()->query($sql, [$deliveryExecutionId]);
+
+                $kvData = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+                echo sprintf('%s kvData found associated to delivery %s', count($kvData), $deliveryExecutionId) . PHP_EOL;
+
+                foreach ($kvData as $data) {
+                    echo $data['monitoring_key'] . ' => ' . $data['monitoring_value'] . PHP_EOL;
+                    $deliveryExecution->addValue($data['monitoring_key'], $data['monitoring_value']);
+                }
+
+                echo sprintf('Saving delivery %s', $deliveryExecutionId) . PHP_EOL;
+
+                if ($monitoringService->partialSave($deliveryExecution)) {
+                    $updated++;
+                } else {
+                    throw new \Exception(sprintf('Unable to save delivery execution %s', $deliveryExecutionId));
+                }
+
+//                $sql = 'DELETE FROM kv_delivery_monitoring WHERE parent_id = ?';
+//
+//                $removed += $monitoringService->getPersistence()->exec($sql, [$deliveryExecutionId]);
+            }
+        }
+
+        echo sprintf('Saved delivery execution: %s', $updated) . PHP_EOL;
+        echo sprintf('ExtraData removed from KV table: %s', $removed) . PHP_EOL;
+
+        die;
+        // foreach count of DX on KV table
+            // fetch chunk of X data by delivery execution
+            // foreach X dx,
+                // json encode ? or set as part DeliveryMonitoringData
+                // put in buffer to later update
+            // update delivery_monitoring
+            // delete kv_delivery_monitoring
+
         $subReport = new Report(Report::TYPE_INFO);
         $removeKV = $this->getOption('deleteKV');
         $persistConfig = $this->getOption('persistConfig');

--- a/scripts/tools/MonitoringExtraFieldMigration.php
+++ b/scripts/tools/MonitoringExtraFieldMigration.php
@@ -72,7 +72,7 @@ class MonitoringExtraFieldMigration extends ScriptAction
 
     protected function provideDescription()
     {
-        return 'This tools take care about KV monitoring data migration to the relational table as extra_data column';
+        return 'This tool takes care about KV monitoring data migration to the relational table as extra_data column';
     }
 
     protected function run()
@@ -162,21 +162,17 @@ class MonitoringExtraFieldMigration extends ScriptAction
             'offset' => $offset,
         ];
 
-        $deliveryExecutions = $this->monitoringService->find([], $options);
+        $unorderedDeliveryExecutions = $this->monitoringService->find([], $options);
 
-        if (!$this->getOption('deleteKv') || !$this->getOption('wet-run')) {
-            $offset += $chunkSize;
+        $offset += $chunkSize;
+
+        $deliveryExecutions = [];
+        foreach ($unorderedDeliveryExecutions as $deliveryExecution) {
+            $deliveryExecutions[$deliveryExecution->get()[DeliveryMonitoringService::DELIVERY_EXECUTION_ID]] = $deliveryExecution;
         }
 
         // Moving percentage
         echo sprintf('%s delivery executions fetched.', count($deliveryExecutions)) . PHP_EOL;
-
-        array_walk(
-            $deliveryExecutions,
-            function(&$key, DeliveryMonitoringData $deliveryExecution) {
-                $key = $deliveryExecution->get()[DeliveryMonitoringService::DELIVERY_EXECUTION_ID];
-            }
-        );
 
         return $this->hydrateDeliveryExecutionsExtraData($deliveryExecutions);
     }
@@ -187,17 +183,18 @@ class MonitoringExtraFieldMigration extends ScriptAction
      */
     private function hydrateDeliveryExecutionsExtraData(array $deliveryExecutions): array
     {
-        $stmt = $this->monitoringService->getPersistence()->query(
-            'SELECT parent_id, monitoring_key, monitoring_value FROM kv_delivery_monitoring WHERE parent_id IN ?',
-            [array_keys($deliveryExecutions)]
+        $sql = sprintf(
+            'SELECT parent_id, monitoring_key, monitoring_value FROM kv_delivery_monitoring WHERE parent_id IN (%s) ',
+            implode(',', array_fill(0, count($deliveryExecutions), '?'))
         );
+        $stmt = $this->monitoringService->getPersistence()->query($sql, array_keys($deliveryExecutions));
 
         $kvData = $stmt->fetchAll(PDO::FETCH_ASSOC);
         foreach ($kvData as $data) {
             $deliveryExecutions[$data['parent_id']]->addValue($data['monitoring_key'], $data['monitoring_value']);
         }
 
-        if (!$this->getOption('wet-run')) {
+        if (!$this->getOption('wet-run') && $this->getOption('deleteKv')) {
             $this->deleted += count($kvData);
         }
 
@@ -225,13 +222,11 @@ class MonitoringExtraFieldMigration extends ScriptAction
 
     private function deleteDeliveryExecutionKvData(DeliveryMonitoringData $deliveryExecution): void
     {
-        if ($this->getOption('deleteKv')) {
-            if ($this->getOption('wet-run')) {
-                $this->deleted += $this->monitoringService->getPersistence()->exec(
-                    'DELETE FROM kv_delivery_monitoring WHERE parent_id = ?',
-                    [$deliveryExecution->get()[DeliveryMonitoringService::DELIVERY_EXECUTION_ID]]
-                );
-            }
+        if ($this->getOption('deleteKv') && $this->getOption('wet-run')) {
+            $this->deleted += $this->monitoringService->getPersistence()->exec(
+                'DELETE FROM kv_delivery_monitoring WHERE parent_id = ?',
+                [$deliveryExecution->get()[DeliveryMonitoringService::DELIVERY_EXECUTION_ID]]
+            );
         }
     }
 
@@ -244,7 +239,8 @@ class MonitoringExtraFieldMigration extends ScriptAction
         if ($wetrun) {
             $report->add(new Report(Report::TYPE_SUCCESS, 'Script runtime executed in `WET_RUN` mode'));
             $report->add(new Report(Report::TYPE_INFO,
-                'You can now check that `kv_delivery_monitoring` table is empty and delete it'
+                'You can now check that `kv_delivery_monitoring` table is empty and delete it. ' .
+                 'Only valid if you have specified --deleteKv flag.'
             ));
 
         } else {

--- a/scripts/tools/MonitoringExtraFieldMigration.php
+++ b/scripts/tools/MonitoringExtraFieldMigration.php
@@ -86,9 +86,9 @@ class MonitoringExtraFieldMigration extends ScriptAction
         }
 
         $count = $this->monitoringService->count();
-        $chunk = ceil($count / $this->getOption('chunkSize'));
+        $chunk = (int) ceil($count / $this->getOption('chunkSize'));
 
-        $this->printMigrationScriptOptions($count, (int) $chunk);
+        $this->printMigrationScriptOptions($count, $chunk);
 
         $offset = 0;
 
@@ -213,15 +213,13 @@ class MonitoringExtraFieldMigration extends ScriptAction
 
     private function deleteDeliveryExecutionKvData(DeliveryMonitoringData $deliveryExecution, array $kvData): void
     {
-        if ($this->getOption('wet-run')) {
-            if ($this->getOption('deleteKv')) {
+        if ($this->getOption('deleteKv')) {
+            if ($this->getOption('wet-run')) {
                 $this->deleted += $this->monitoringService->getPersistence()->exec(
                     'DELETE FROM kv_delivery_monitoring WHERE parent_id = ?',
                     [$deliveryExecution->get()[DeliveryMonitoringService::DELIVERY_EXECUTION_ID]]
                 );
-            }
-        }  else {
-            if ($this->getOption('deleteKv')) {
+            }  else {
                 $this->deleted += count($kvData);
             }
         }


### PR DESCRIPTION
**Description**
Create a script to move delivery extra data from kv_delivery_monitoring table to delivery_monitoring extra_data column
This PR also contains a fix to update extra_data column when it is null
**Ticket**
https://oat-sa.atlassian.net/browse/PR-495
**How to test**
Install sprint 134
Pass couple of delivery_execution (LTI or not) to produce extra_data
Update to ltiProctoring to v9.1.1
Run the script to create extra_column / configure monitoring to use SimpleMonitoring storage
Run the script (use -h for further options)
```
php index.php '\oat\taoProctoring\scripts\tools\MonitoringExtraFieldMigration' -h
```
Data should be moved to delivery_monitoring extra_data column