### PR TITLE
Feature/pr 520/remove kv table

### DIFF
--- a/config/default/MonitoringListener.conf.php
+++ b/config/default/MonitoringListener.conf.php
@@ -2,7 +2,6 @@
 /**
  * Default config header
  *
- * To replace this add a file C:\domains\package-tao\taoProctoring\config/header/TestSessionConnectivityStatusService.conf.php
  */
 
 return new \oat\taoProctoring\model\listener\MonitoringListener();

--- a/config/default/MonitoringListener.conf.php
+++ b/config/default/MonitoringListener.conf.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Default config header
+ *
+ * To replace this add a file C:\domains\package-tao\taoProctoring\config/header/TestSessionConnectivityStatusService.conf.php
+ */
+
+return new \oat\taoProctoring\model\listener\MonitoringListener();

--- a/migrations/Version202106081338544101_taoProctoring.php
+++ b/migrations/Version202106081338544101_taoProctoring.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 namespace oat\taoProctoring\migrations;
 
 use Exception;
-use common_report_Report as Report;
+use oat\oatbox\reporting\Report as Report;
 use common_persistence_SqlPersistence;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;
@@ -61,7 +61,12 @@ final class Version202106081338544101_taoProctoring extends AbstractMigration
             } else {
                 throw new Exception("Unsupported platform: $platformName");
             }
-            $this->addReport(Report::createSuccess('`extra_data` column was created in `delivery_monitoring` table'));
+            $this->addReport(new Report(Report::TYPE_SUCCESS, '`extra_data` column was created in `delivery_monitoring` table'));
+            $this->addReport(new Report(
+                Report::TYPE_INFO,
+                'You can now change configuration to use this new column via: ' . PHP_EOL .
+                '`php index.php \'\oat\taoProctoring\scripts\tools\MonitoringExtraFieldConfigurationMigration\'`'
+            ));
         } catch (Exception $e) {
             $this->addReport(
                 new Report(

--- a/migrations/Version202106081338544101_taoProctoring.php
+++ b/migrations/Version202106081338544101_taoProctoring.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoProctoring\migrations;
+
+use Exception;
+use common_report_Report as Report;
+use common_persistence_SqlPersistence;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use oat\generis\persistence\PersistenceManager;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoProctoring\model\monitorCache\implementation\SimpleMonitoringStorage;
+
+final class Version202106081338544101_taoProctoring extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Creates new `extra_data` column in `delivery_monitoring` to store extra data.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        try {
+            $persistence = $this->getPersistence();
+
+            $platformName = $persistence->getPlatForm()->getName();
+            if ($platformName == 'mysql') {
+                $schema = $persistence->getSchemaManager()->createSchema();
+                $fromSchema = clone $schema;
+
+                $table = $schema->getTable(SimpleMonitoringStorage::TABLE_NAME);
+                $table->addColumn(SimpleMonitoringStorage::COLUMN_EXTRA_DATA, Types::JSON, array("notnull" => false));
+                $persistence->getPlatForm()->migrateSchema($fromSchema, $schema);
+            } elseif ($platformName == 'postgresql') {
+                $query = sprintf(
+                    'ALTER TABLE %s ADD COLUMN %s jsonb',
+                    SimpleMonitoringStorage::TABLE_NAME,
+                    SimpleMonitoringStorage::COLUMN_EXTRA_DATA
+                );
+                $persistence->exec($query);
+            } else {
+                throw new Exception("Unsupported platform: $platformName");
+            }
+            $this->addReport(Report::createSuccess('`extra_data` column was created in `delivery_monitoring` table'));
+        } catch (Exception $e) {
+            $this->addReport(
+                new Report(
+                    Report::TYPE_ERROR,
+                    'Failed to create `extra_data` column in `delivery_monitoring`',
+                    [
+                        'message' => $e->getMessage(),
+                        'trace' => $e->getTrace(),
+                    ]
+                )
+            );
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $persistence = $this->getPersistence();
+        $schema = $persistence->getSchemaManager()->createSchema();
+        $fromSchema = clone $schema;
+
+        $table = $schema->getTable(SimpleMonitoringStorage::TABLE_NAME);
+        if ($table->hasColumn(SimpleMonitoringStorage::COLUMN_EXTRA_DATA)) {
+            $table->dropColumn(SimpleMonitoringStorage::COLUMN_EXTRA_DATA);
+        }
+        $persistence->getPlatForm()->migrateSchema($fromSchema, $schema);
+        $this->addReport(Report::createSuccess('`extra_data` column was deleted in `delivery_monitoring` table'));
+    }
+
+    private function getPersistence(): common_persistence_SqlPersistence
+    {
+        return $this->getServiceLocator()
+            ->get(PersistenceManager::SERVICE_ID)
+            ->getPersistenceById('default');
+    }
+}

--- a/migrations/Version202106081338544101_taoProctoring.php
+++ b/migrations/Version202106081338544101_taoProctoring.php
@@ -29,7 +29,7 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;
 use oat\generis\persistence\PersistenceManager;
 use oat\tao\scripts\tools\migrations\AbstractMigration;
-use oat\taoProctoring\model\monitorCache\implementation\SimpleMonitoringStorage;
+use oat\taoProctoring\model\repository\MonitoringRepository;
 
 final class Version202106081338544101_taoProctoring extends AbstractMigration
 {
@@ -48,14 +48,14 @@ final class Version202106081338544101_taoProctoring extends AbstractMigration
                 $schema = $persistence->getSchemaManager()->createSchema();
                 $fromSchema = clone $schema;
 
-                $table = $schema->getTable(SimpleMonitoringStorage::TABLE_NAME);
-                $table->addColumn(SimpleMonitoringStorage::COLUMN_EXTRA_DATA, Types::JSON, array("notnull" => false));
+                $table = $schema->getTable(MonitoringRepository::TABLE_NAME);
+                $table->addColumn(MonitoringRepository::COLUMN_EXTRA_DATA, Types::JSON, array("notnull" => false));
                 $persistence->getPlatForm()->migrateSchema($fromSchema, $schema);
             } elseif ($platformName == 'postgresql') {
                 $query = sprintf(
                     'ALTER TABLE %s ADD COLUMN %s jsonb',
-                    SimpleMonitoringStorage::TABLE_NAME,
-                    SimpleMonitoringStorage::COLUMN_EXTRA_DATA
+                    MonitoringRepository::TABLE_NAME,
+                    MonitoringRepository::COLUMN_EXTRA_DATA
                 );
                 $persistence->exec($query);
             } else {
@@ -82,9 +82,9 @@ final class Version202106081338544101_taoProctoring extends AbstractMigration
         $schema = $persistence->getSchemaManager()->createSchema();
         $fromSchema = clone $schema;
 
-        $table = $schema->getTable(SimpleMonitoringStorage::TABLE_NAME);
-        if ($table->hasColumn(SimpleMonitoringStorage::COLUMN_EXTRA_DATA)) {
-            $table->dropColumn(SimpleMonitoringStorage::COLUMN_EXTRA_DATA);
+        $table = $schema->getTable(MonitoringRepository::TABLE_NAME);
+        if ($table->hasColumn(MonitoringRepository::COLUMN_EXTRA_DATA)) {
+            $table->dropColumn(MonitoringRepository::COLUMN_EXTRA_DATA);
         }
         $persistence->getPlatForm()->migrateSchema($fromSchema, $schema);
         $this->addReport(Report::createSuccess('`extra_data` column was deleted in `delivery_monitoring` table'));

--- a/model/datatable/DeliveriesActivityDatatable.php
+++ b/model/datatable/DeliveriesActivityDatatable.php
@@ -26,6 +26,7 @@ use oat\tao\model\datatable\DatatablePayload;
 use oat\oatbox\service\ServiceManager;
 use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
 use oat\taoProctoring\model\ActivityMonitoringService;
+use oat\taoProctoring\model\monitorCache\implementation\MonitoringStorage;
 use Zend\ServiceManager\ServiceLocatorAwareInterface;
 use Zend\ServiceManager\ServiceLocatorAwareTrait;
 
@@ -60,8 +61,8 @@ class DeliveriesActivityDatatable implements DatatablePayload, ServiceLocatorAwa
 
     public function getPayload()
     {
-        /** @var \oat\taoProctoring\model\monitorCache\implementation\MonitoringStorage $service */
-        $service = $this->getServiceLocator()->get(\oat\taoProctoring\model\monitorCache\implementation\MonitoringStorage::SERVICE_ID);
+        /** @var MonitoringStorage $service */
+        $service = $this->getServiceLocator()->get(MonitoringStorage::SERVICE_ID);
 
         $offset = ($this->request->getPage() - 1) * $this->request->getRows() ? : 0;
         $limit = $this->request->getRows() ? : 0;
@@ -81,8 +82,8 @@ class DeliveriesActivityDatatable implements DatatablePayload, ServiceLocatorAwa
      */
     protected function doPostProcessing(array $result)
     {
-        /** @var \oat\taoProctoring\model\monitorCache\implementation\MonitoringStorage $service */
-        $service = $this->getServiceLocator()->get(\oat\taoProctoring\model\monitorCache\implementation\MonitoringStorage::SERVICE_ID);
+        /** @var MonitoringStorage $service */
+        $service = $this->getServiceLocator()->get(MonitoringStorage::SERVICE_ID);
         $rows = $this->request->getRows();
         $rows = $rows?:1;
         $total = $service->getCountOfStatistics();

--- a/model/datatable/DeliveriesActivityDatatable.php
+++ b/model/datatable/DeliveriesActivityDatatable.php
@@ -26,6 +26,7 @@ use oat\tao\model\datatable\DatatablePayload;
 use oat\oatbox\service\ServiceManager;
 use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
 use oat\taoProctoring\model\ActivityMonitoringService;
+use oat\taoProctoring\model\monitorCache\DeliveryMonitoringService;
 use oat\taoProctoring\model\monitorCache\implementation\MonitoringStorage;
 use Zend\ServiceManager\ServiceLocatorAwareInterface;
 use Zend\ServiceManager\ServiceLocatorAwareTrait;
@@ -61,8 +62,8 @@ class DeliveriesActivityDatatable implements DatatablePayload, ServiceLocatorAwa
 
     public function getPayload()
     {
-        /** @var MonitoringStorage $service */
-        $service = $this->getServiceLocator()->get(MonitoringStorage::SERVICE_ID);
+        /** @var DeliveryMonitoringService $service */
+        $service = $this->getServiceLocator()->get(DeliveryMonitoringService::SERVICE_ID);
 
         $offset = ($this->request->getPage() - 1) * $this->request->getRows() ? : 0;
         $limit = $this->request->getRows() ? : 0;
@@ -82,8 +83,8 @@ class DeliveriesActivityDatatable implements DatatablePayload, ServiceLocatorAwa
      */
     protected function doPostProcessing(array $result)
     {
-        /** @var MonitoringStorage $service */
-        $service = $this->getServiceLocator()->get(MonitoringStorage::SERVICE_ID);
+        /** @var DeliveryMonitoringService $service */
+        $service = $this->getServiceLocator()->get(DeliveryMonitoringService::SERVICE_ID);
         $rows = $this->request->getRows();
         $rows = $rows?:1;
         $total = $service->getCountOfStatistics();

--- a/model/listener/MonitoringListener.php
+++ b/model/listener/MonitoringListener.php
@@ -51,14 +51,12 @@ use oat\taoQtiTest\models\event\QtiTestStateChangeEvent;
 use oat\taoProctoring\model\authorization\AuthorizationGranted;
 use tao_helpers_Date;
 
-class MonitoringListener extends ConfigurableService
+class MonitoringListener extends ConfigurableService implements MonitoringListenerInterface
 {
     /**
-     * @param DeliveryExecutionCreated $event
      * @throws common_exception_NotFound
-     * @throws Exception
      */
-    public function executionCreated(DeliveryExecutionCreated $event)
+    public function executionCreated(DeliveryExecutionCreated $event): void
     {
         $deliveryExecution = $event->getDeliveryExecution();
 
@@ -75,12 +73,9 @@ class MonitoringListener extends ConfigurableService
     }
 
     /**
-     * @param DeliveryExecutionState $event
-     * @throws common_exception_Error
-     * @throws common_exception_NotFound
-     * @throws Exception
+     * @throws common_exception_Error|common_exception_NotFound|Exception
      */
-    public function executionStateChanged(DeliveryExecutionState $event)
+    public function executionStateChanged(DeliveryExecutionState $event): void
     {
         $data = $this->getMonitoringRepository()->createMonitoringData($event->getDeliveryExecution());
 
@@ -93,12 +88,9 @@ class MonitoringListener extends ConfigurableService
     }
 
     /**
-     * @param DeliveryExecutionState $event
-     * @param DeliveryMonitoringData $data
-     * @throws common_exception_Error
-     * @throws common_exception_NotFound
+     * @throws common_exception_Error|common_exception_NotFound
      */
-    protected function fillMonitoringOnExecutionStateChanged(DeliveryExecutionState $event, DeliveryMonitoringData $data)
+    protected function fillMonitoringOnExecutionStateChanged(DeliveryExecutionState $event, DeliveryMonitoringData $data): void
     {
         $data->update(DeliveryMonitoringService::STATUS, $event->getState());
         $data->updateData([DeliveryMonitoringService::CONNECTIVITY]);
@@ -124,15 +116,11 @@ class MonitoringListener extends ConfigurableService
     }
 
     /**
-     * Something changed in the state of the test execution
-     * (for example: the current item in the test)
+     * Something changed in the state of the test execution (for example: the current item in the test)
      *
-     * @param TestChangedEvent $event
-     * @throws common_exception_NotFound
-     * @throws common_exception_Error
-     * @throws Exception
+     * @throws common_exception_NotFound|common_exception_Error
      */
-    public function testStateChanged(TestChangedEvent $event)
+    public function testStateChanged(TestChangedEvent $event): void
     {
         $deliveryExecution = $this->getServiceLocator()->get(DeliveryExecutionService::SERVICE_ID)
             ->getDeliveryExecution($event->getServiceCallId());
@@ -168,14 +156,11 @@ class MonitoringListener extends ConfigurableService
     }
 
     /**
-     * The status of the test execution has changed
-     * (for example: from running to paused)
+     * The status of the test execution has change (for example: from running to paused)
      *
-     * @param QtiTestStateChangeEvent $event
      * @throws common_exception_NotFound
-     * @throws Exception
      */
-    public function qtiTestStatusChanged(QtiTestStateChangeEvent $event)
+    public function qtiTestStatusChanged(QtiTestStateChangeEvent $event): void
     {
         /** @var DeliveryExecutionService $deliveryExecutionService */
         $deliveryExecutionService = $this->getServiceLocator()->get(DeliveryExecutionService::SERVICE_ID);
@@ -196,11 +181,11 @@ class MonitoringListener extends ConfigurableService
     }
 
     /**
-     * Update the label of the delivery across the entrie cache
+     * Update the label of the delivery across the entry cache
      *
      * @param MetadataModified $event
      */
-    public function deliveryLabelChanged(MetadataModified $event)
+    public function deliveryLabelChanged(MetadataModified $event): void
     {
         $resource = $event->getResource();
         if ($event->getMetadataUri() === OntologyRdfs::RDFS_LABEL) {
@@ -218,13 +203,11 @@ class MonitoringListener extends ConfigurableService
     }
 
     /**
-     * Sets the protor who authorized this delivery execution
+     * Set the proctor who authorized this delivery execution
      *
-     * @param AuthorizationGranted $event
      * @throws common_exception_NotFound
-     * @throws Exception
      */
-    public function deliveryAuthorized(AuthorizationGranted $event)
+    public function deliveryAuthorized(AuthorizationGranted $event): void
     {
         $deliveryExecution = $event->getDeliveryExecution();
         $data = $this->getMonitoringRepository()->createMonitoringData($deliveryExecution);
@@ -236,11 +219,9 @@ class MonitoringListener extends ConfigurableService
     }
 
     /**
-     * @param DeliveryExecutionReactivated $event
      * @throws common_exception_NotFound
-     * @throws Exception
      */
-    public function catchTestReactivatedEvent(DeliveryExecutionReactivated $event)
+    public function catchTestReactivatedEvent(DeliveryExecutionReactivated $event): void
     {
         $deliveryExecution = $event->getDeliveryExecution();
 
@@ -254,14 +235,8 @@ class MonitoringListener extends ConfigurableService
         }
     }
 
-    /**
-     * @param DeliveryMonitoringData $data
-     * @param User $user
-     * @return DeliveryMonitoringData
-     */
-    private function updateTestTakerInformation($data, $user)
+    private function updateTestTakerInformation(DeliveryMonitoringData $data, User $user): DeliveryMonitoringData
     {
-        // need to add user to event
         $firstNames = $user->getPropertyValues(GenerisRdf::PROPERTY_USER_FIRSTNAME);
         if (!empty($firstNames)) {
             $data->update(DeliveryMonitoringService::TEST_TAKER_FIRST_NAME, reset($firstNames));
@@ -274,13 +249,7 @@ class MonitoringListener extends ConfigurableService
         return $data;
     }
 
-    /**
-     * @param DeliveryMonitoringData $data
-     * @param DeliveryExecutionInterface $deliveryExecution
-     * @return DeliveryMonitoringData
-     * @throws common_exception_NotFound
-     */
-    private function updateDeliveryInformation($data, $deliveryExecution)
+    private function updateDeliveryInformation(DeliveryMonitoringData $data, DeliveryExecutionInterface $deliveryExecution): DeliveryMonitoringData
     {
         $data->update(DeliveryMonitoringService::STATUS, $deliveryExecution->getState()->getUri());
         $data->update(DeliveryMonitoringService::TEST_TAKER, $deliveryExecution->getUserIdentifier());

--- a/model/listener/MonitoringListenerInterface.php
+++ b/model/listener/MonitoringListenerInterface.php
@@ -36,7 +36,7 @@ use oat\taoTests\models\event\TestChangedEvent;
 
 interface MonitoringListenerInterface
 {
-    public const SERVICE_ID = 'tapProctoring/MonitoringListener';
+    public const SERVICE_ID = 'taoProctoring/MonitoringListener';
 
     /**
      * @throws common_exception_NotFound

--- a/model/listener/MonitoringListenerInterface.php
+++ b/model/listener/MonitoringListenerInterface.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoProctoring\model\listener;
+
+use common_exception_Error;
+use common_exception_NotFound;
+use Exception;
+use oat\tao\model\event\MetadataModified;
+use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionCreated;
+use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionReactivated;
+use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState;
+use oat\taoProctoring\model\authorization\AuthorizationGranted;
+use oat\taoQtiTest\models\event\QtiTestStateChangeEvent;
+use oat\taoTests\models\event\TestChangedEvent;
+
+interface MonitoringListenerInterface
+{
+    public const SERVICE_ID = 'tapProctoring/MonitoringListener';
+
+    /**
+     * @throws common_exception_NotFound
+     */
+    public function executionCreated(DeliveryExecutionCreated $event): void;
+
+    /**
+     * @throws common_exception_Error|common_exception_NotFound|Exception
+     */
+    public function executionStateChanged(DeliveryExecutionState $event): void;
+    /**
+     * Something changed in the state of the test execution (for example: the current item in the test)
+     *
+     * @throws common_exception_NotFound|common_exception_Error
+     */
+    public function testStateChanged(TestChangedEvent $event): void;
+
+    /**
+     * The status of the test execution has change (for example: from running to paused)
+     *
+     * @throws common_exception_NotFound
+     */
+    public function qtiTestStatusChanged(QtiTestStateChangeEvent $event): void;
+
+    /**
+     * Update the label of the delivery across the entry cache
+     *
+     * @param MetadataModified $event
+     */
+    public function deliveryLabelChanged(MetadataModified $event): void;
+
+    /**
+     * Set the proctor who authorized this delivery execution
+     *
+     * @throws common_exception_NotFound
+     */
+    public function deliveryAuthorized(AuthorizationGranted $event): void;
+
+    /**
+     * @throws common_exception_NotFound
+     */
+    public function catchTestReactivatedEvent(DeliveryExecutionReactivated $event): void;
+}

--- a/model/monitorCache/DeliveryMonitoringService.php
+++ b/model/monitorCache/DeliveryMonitoringService.php
@@ -117,13 +117,13 @@ interface DeliveryMonitoringService extends DeliveryExecutionDelete
     public function count();
 
     /**
-     * Get statistic by statuses groped by deliveries.
+     * Get statistic by statuses grouped by deliveries.
      * Result is an array of deliveries with amount of delivery executions in each status
-     * @param integer $limit
-     * @param integer $offset
-     * @param string $orderby - status uri to order
-     * @param string $orderdir - status uri to order
-     * @return mixed
      */
     public function getStatusesStatistic($limit = 0, $offset = 0, $orderby = 'delivery_name', $orderdir = 'asc');
+
+    /**
+     * Count statistic by statuses grouped by deliveries.
+     */
+    public function getCountOfStatistics();
 }

--- a/model/monitorCache/implementation/MonitorCacheService.php
+++ b/model/monitorCache/implementation/MonitorCacheService.php
@@ -26,7 +26,6 @@ use oat\generis\model\OntologyRdfs;
 use oat\tao\model\taskQueue\QueueDispatcherInterface;
 use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
 use oat\taoDelivery\model\execution\DeliveryExecutionService;
-use oat\taoDelivery\model\execution\ServiceProxy;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionCreated;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionReactivated;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState;
@@ -49,7 +48,7 @@ use oat\taoProctoring\model\authorization\AuthorizationGranted;
  * @package oat\taoProctoring\model
  * @author Aleh Hutnikau <hutnikau@1pt.com>
  */
-class MonitorCacheService extends MonitoringStorage
+class MonitorCacheService extends SimpleMonitoringStorage
 {
     /**
      * @param DeliveryExecutionCreated $event
@@ -129,7 +128,7 @@ class MonitorCacheService extends MonitoringStorage
      */
     public function testStateChanged(TestChangedEvent $event)
     {
-        $deliveryExecution = ServiceProxy::singleton()->getDeliveryExecution($event->getServiceCallId());
+        $deliveryExecution = $this->getServiceLocator()->get(DeliveryExecutionService::SERVICE_ID)->getDeliveryExecution($event->getServiceCallId());
 
         $data = $this->createMonitoringData($deliveryExecution);
 

--- a/model/monitorCache/implementation/MonitoringStorage.php
+++ b/model/monitorCache/implementation/MonitoringStorage.php
@@ -71,6 +71,8 @@ use oat\taoProctoring\model\execution\DeliveryExecution as ProctoredDeliveryExec
  *
  * @package oat\taoProctoring\model
  * @author Aleh Hutnikau <hutnikau@1pt.com>
+ *
+ * @deprecated 
  */
 class MonitoringStorage extends ConfigurableService implements DeliveryMonitoringService
 {

--- a/model/monitorCache/implementation/SimpleMonitoringStorage.php
+++ b/model/monitorCache/implementation/SimpleMonitoringStorage.php
@@ -1,0 +1,719 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoProctoring\model\monitorCache\implementation;
+
+use common_exception_NotFound;
+use common_persistence_SqlPersistence;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Exception;
+use oat\generis\persistence\PersistenceManager;
+use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
+use oat\taoDelivery\model\execution\ServiceProxy;
+use oat\taoDelivery\model\execution\Delete\DeliveryExecutionDeleteRequest;
+use oat\taoProctoring\model\monitorCache\DeliveryMonitoringService;
+use oat\taoProctoring\model\monitorCache\DeliveryMonitoringData as DeliveryMonitoringDataInterface;
+use oat\oatbox\service\ConfigurableService;
+use oat\generis\model\OntologyAwareTrait;
+use oat\taoProctoring\model\execution\DeliveryExecution as ProctoredDeliveryExecution;
+use PDO;
+use PDOException;
+
+class SimpleMonitoringStorage extends ConfigurableService implements DeliveryMonitoringService
+{
+    use OntologyAwareTrait;
+
+    const OPTION_PERSISTENCE = 'persistence';
+    const OPTION_USE_UPDATE_MULTIPLE = 'use_update_multiple';
+
+    const OPTION_PRIMARY_COLUMNS = 'primary_columns';
+
+    const TABLE_NAME = 'delivery_monitoring';
+
+    const COLUMN_ID = DeliveryMonitoringService::DELIVERY_EXECUTION_ID;
+    const COLUMN_DELIVERY_EXECUTION_ID = DeliveryMonitoringService::DELIVERY_EXECUTION_ID;
+    const COLUMN_STATUS = DeliveryMonitoringService::STATUS;
+    const COLUMN_CURRENT_ASSESSMENT_ITEM = DeliveryMonitoringService::CURRENT_ASSESSMENT_ITEM;
+    const COLUMN_TEST_TAKER = DeliveryMonitoringService::TEST_TAKER;
+    const COLUMN_TEST_TAKER_FIRST_NAME = DeliveryMonitoringService::TEST_TAKER_FIRST_NAME;
+    const COLUMN_TEST_TAKER_LAST_NAME = DeliveryMonitoringService::TEST_TAKER_LAST_NAME;
+    const COLUMN_AUTHORIZED_BY = DeliveryMonitoringService::AUTHORIZED_BY;
+    const COLUMN_START_TIME = DeliveryMonitoringService::START_TIME;
+    const COLUMN_END_TIME = DeliveryMonitoringService::END_TIME;
+    const COLUMN_REMAINING_TIME = DeliveryMonitoringService::REMAINING_TIME;
+    const COLUMN_EXTRA_TIME = DeliveryMonitoringService::EXTRA_TIME;
+    const COLUMN_CONSUMED_EXTRA_TIME = DeliveryMonitoringService::CONSUMED_EXTRA_TIME;
+
+    const COLUMN_EXTRA_DATA = 'extra_data';
+
+    const DEFAULT_SORT_COLUMN = self::COLUMN_ID;
+    const DEFAULT_SORT_ORDER = 'ASC';
+    const DEFAULT_SORT_TYPE = 'string';
+
+    private $queryParams = [];
+
+    /**
+     * @param DeliveryExecutionInterface $deliveryExecution
+     * @param $data
+     * @return DeliveryMonitoringData
+     * @throws common_exception_NotFound
+     */
+    public function createMonitoringData(DeliveryExecutionInterface $deliveryExecution, $data = [])
+    {
+        $data = array_merge([
+            DeliveryMonitoringService::DELIVERY_EXECUTION_ID => $deliveryExecution->getIdentifier(),
+        ], $data);
+
+        if (!array_key_exists(DeliveryMonitoringService::STATUS, $data)) {
+            $data[DeliveryMonitoringService::STATUS] = $deliveryExecution->getState()->getUri();
+        }
+
+        // @todo data object should not use ServiceLocator
+        $monitoringData = new DeliveryMonitoringData($deliveryExecution, $data);
+        $this->propagate($monitoringData);
+
+        return $monitoringData;
+    }
+
+    /**
+     * @param DeliveryExecutionInterface $deliveryExecution
+     * @return array|DeliveryMonitoringData
+     * @throws common_exception_NotFound
+     */
+    public function getData(DeliveryExecutionInterface $deliveryExecution): DeliveryMonitoringData
+    {
+        return $this->createMonitoringData(
+            $deliveryExecution,
+            $this->loadData($deliveryExecution->getIdentifier())
+        );
+    }
+
+    /**
+     * @param array $criteria
+     * @param array $options
+     * @return DeliveryMonitoringData[]
+     * @throws common_exception_NotFound
+     */
+    public function find(array $criteria = [], array $options = []): array
+    {
+        $this->queryParams = [];
+
+        $whereClause = $this->prepareCondition($criteria, $this->queryParams);
+        if ($whereClause !== '') {
+            $whereClause = 'WHERE ' . $whereClause;
+        }
+
+        $defaultOptions = [
+            'order' => join(' ', [static::DEFAULT_SORT_COLUMN, static::DEFAULT_SORT_ORDER, static::DEFAULT_SORT_TYPE]),
+            'offset' => 0,
+            'asArray' => false
+        ];
+        $options = array_merge($defaultOptions, $options);
+
+        $orderClause = $this->prepareOrderStmt($options['order']);
+        if ($orderClause !== '') {
+            $orderClause = 'ORDER BY ' . $orderClause;
+        }
+
+        $sql = sprintf(
+            'SELECT %s FROM %s t %s %s',
+            implode(', ', $this->getPrimaryColumns()),
+            self::TABLE_NAME,
+            $whereClause,
+            $orderClause
+        );
+
+        if (isset($options['limit']))  {
+            $sql = $this->getPersistence()->getPlatForm()->limitStatement($sql, $options['limit'], $options['offset']);
+        }
+
+        $stmt = $this->getPersistence()->query($sql, $this->queryParams);
+
+        $data = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        foreach($data as &$row) {
+            $extraData = [];
+            if (isset($row[self::COLUMN_EXTRA_DATA])) {
+                $decodedExtraData = json_decode($row[self::COLUMN_EXTRA_DATA]);
+                if (json_last_error() === JSON_ERROR_NONE) {
+                    $extraData = $decodedExtraData;
+                }
+            }
+            unset($row[self::COLUMN_EXTRA_DATA]);
+            $row = array_merge($row, $extraData);
+
+            if (!$options['asArray']) {
+                $deliveryExecution = ServiceProxy::singleton()->getDeliveryExecution($row[self::COLUMN_DELIVERY_EXECUTION_ID]);
+                $row = $this->createMonitoringData($deliveryExecution, $row);
+            }
+        }
+
+        return $data;
+    }
+
+    public function count(array $criteria = []): int
+    {
+        $this->queryParams = [];
+
+        $whereClause = $this->prepareCondition($criteria, $this->queryParams);
+        if ($whereClause !== '') {
+            $whereClause = 'WHERE ' . $whereClause;
+        }
+
+        $sql = sprintf('select count(*) from %s t %s', self::TABLE_NAME, $whereClause);
+
+        $stmt = $this->getPersistence()->query($sql, $this->queryParams);
+        $result = $stmt->fetch(PDO::FETCH_BOTH);
+
+        return (int) $result[0];
+    }
+
+    /**
+     * @param DeliveryMonitoringDataInterface $deliveryMonitoring
+     * @return bool|mixed
+     * @throws Exception
+     */
+    public function save(DeliveryMonitoringDataInterface $deliveryMonitoring): bool
+    {
+        $result = false;
+        if ($deliveryMonitoring->validate()) {
+            try {
+                // we should be ready for unique violation error when the calling side calls
+                // save() instead of partialSave()
+                $result = $this->create($deliveryMonitoring);
+            } catch (PDOException $e) {
+                // when the PDO implementation of RDS is used as a persistence
+                // unfortunately the exception is very broad so it can cover more than intended cases
+            } catch (UniqueConstraintViolationException $e) {
+                // when the DBAL implementation of RDS is used as a persistence
+            }
+            if (!$result) {
+                $this->update($deliveryMonitoring);
+            }
+
+            $result = true;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param DeliveryMonitoringDataInterface $deliveryMonitoring
+     * @return bool
+     * @throws Exception
+     */
+    public function partialSave(DeliveryMonitoringDataInterface $deliveryMonitoring): bool
+    {
+        $result = false;
+        if ($deliveryMonitoring->validate()) {
+            $rowsUpdated = $this->update($deliveryMonitoring);
+            if ($rowsUpdated === 0) {
+                // doesn't mean an error for sure, cause persistence may return the number of rows actually changed,
+                // and not the number of rows matched by the where clause.
+                // So just in case try to create without fallback
+                try {
+                    $this->create($deliveryMonitoring);
+                } catch (PDOException $e) {
+                    // when the PDO implementation of RDS is used as a persistence
+                } catch (UniqueConstraintViolationException $e) {
+                    // when the DBAL implementation of RDS is used as a persistence
+                }
+            }
+
+            $result = true;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param DeliveryMonitoringDataInterface $deliveryMonitoring
+     * @return boolean
+     */
+    public function delete(DeliveryMonitoringDataInterface $deliveryMonitoring): bool
+    {
+        $data = $deliveryMonitoring->get();
+
+        $sql = sprintf('DELETE FROM %s WHERE %s = ?', self::TABLE_NAME, self::COLUMN_DELIVERY_EXECUTION_ID);
+
+        return $this->getPersistence()->exec($sql, [$data[self::COLUMN_DELIVERY_EXECUTION_ID]]) === 1;
+    }
+
+    /**
+     * @return common_persistence_SqlPersistence
+     */
+    public function getPersistence()
+    {
+        return $this->getServiceLocator()
+            ->get(PersistenceManager::SERVICE_ID)
+            ->getPersistenceById($this->getOption(self::OPTION_PERSISTENCE));
+    }
+
+    /**
+     * @todo extract this method to another service with statistic responsabilities
+     *
+     * @return mixed
+     */
+    public function getCountOfStatistics()
+    {
+        $groupedQueryBuilder = $this->getQueryBuilder();
+        $groupedQueryBuilder->select('delivery_monitoring.delivery_id');
+        $groupedQueryBuilder->from('delivery_monitoring');
+        $groupedQueryBuilder->groupBy('delivery_monitoring.delivery_id');
+        $groupedSql = $groupedQueryBuilder->getSQL();
+
+        $countQueryBuilder = $this->getQueryBuilder();
+        $countQueryBuilder->select('count(grouped.delivery_id)');
+        $countQueryBuilder->from('('.$groupedSql.')', 'grouped');
+        $stmt = $this->getPersistence()->query($countQueryBuilder->getSQL());
+        return $stmt->fetch(PDO::FETCH_COLUMN);
+    }
+
+    /**
+     * @todo extract this method to another service with statistic responsabilities
+     * @todo query of 150 lines, erf
+     *
+     * @param int $limit
+     * @param int $offset
+     * @param string $orderby
+     * @param string $orderdir
+     * @return mixed|void
+     */
+    public function getStatusesStatistic($limit = 10, $offset = 0, $orderby = 'label', $orderdir = 'asc')
+    {
+        $statusesList = [
+            $this->getResource(ProctoredDeliveryExecution::STATE_ACTIVE),
+            $this->getResource(ProctoredDeliveryExecution::STATE_AUTHORIZED),
+            $this->getResource(ProctoredDeliveryExecution::STATE_AWAITING),
+            $this->getResource(ProctoredDeliveryExecution::STATE_CANCELED),
+            $this->getResource(ProctoredDeliveryExecution::STATE_FINISHED),
+            $this->getResource(ProctoredDeliveryExecution::STATE_PAUSED),
+            $this->getResource(ProctoredDeliveryExecution::STATE_TERMINATED)
+        ];
+        $statusesMap = [];
+        foreach ($statusesList as $status) {
+            $statusesMap[$status->getLabel()] = $status->getUri();
+        }
+
+        $paramsValues = [];
+        $limitQueryBuilder = $this->getQueryBuilder();
+        $limitQueryBuilder->select('limit_q.delivery_id');
+        $limitQueryBuilder->groupBy('limit_q.delivery_id');
+
+        if (isset($statusesMap[$orderby])) {
+            $innerQueryBuilder = $this->getQueryBuilder();
+            $innerQueryBuilder->select('delivery_monitoring.delivery_id');
+            $innerQueryBuilder->addSelect('COALESCE( order_join.order_status, 0 ) as order_val');
+            $innerQueryBuilder->from('delivery_monitoring');
+
+            $statusBuilder = $this->getQueryBuilder();
+            $statusBuilder->select('status_d_m.delivery_id, count(status_d_m.status) order_status');
+            $statusBuilder->from('delivery_monitoring', 'status_d_m');
+            $statusBuilder->where('status_d_m.status = :status_order');
+            $paramsValues[':status_order'] =  $statusesMap[$orderby];
+            $statusBuilder->groupBy('status_d_m.delivery_id');
+            $statusSql = $statusBuilder->getSQL();
+
+            $innerQueryBuilder->leftJoin(
+                'delivery_monitoring',
+                '('.$statusSql.')',
+                'order_join',
+                'order_join.delivery_id=delivery_monitoring.delivery_id'
+            );
+            $innerQueryBuilder->groupBy('delivery_monitoring.delivery_id, order_val');
+            $innerQueryBuilder->orderBy('order_val', $orderdir);
+
+            if ($limit) {
+                $innerQueryBuilder->setMaxResults($limit);
+            }
+            $innerQueryBuilder->setFirstResult($offset);
+
+            $innerSql = $innerQueryBuilder->getSQL();
+            $limitQueryBuilder->from('('.$innerSql.')', 'limit_q');
+            $limitQueryBuilder->addGroupBy('limit_q.order_val');
+            $limitQueryBuilder->orderBy('order_val', $orderdir);
+        } else if($orderby == 'label') {
+            $limitQueryBuilder->from('delivery_monitoring', 'limit_q');
+            $limitQueryBuilder->addSelect('limit_q.delivery_name');
+            $limitQueryBuilder->addGroupBy('limit_q.delivery_name');
+            $limitQueryBuilder->orderBy('limit_q.delivery_name', $orderdir);
+            if ($limit) {
+                $limitQueryBuilder->setMaxResults($limit);
+            }
+            $limitQueryBuilder->setFirstResult($offset);
+        } else {
+            $limitQueryBuilder->from('delivery_monitoring', 'limit_q');
+            $limitQueryBuilder->addSelect('max(limit_q.start_time) as max_start_time');
+            $limitQueryBuilder->orderBy('max_start_time', $orderdir);
+            if ($limit) {
+                $limitQueryBuilder->setMaxResults($limit);
+            }
+            $limitQueryBuilder->setFirstResult($offset);
+        }
+        $limitQueryBuilder->andWhere('limit_q.delivery_id IS NOT NULL');
+        $limitSql = $limitQueryBuilder->getSQL();
+        $stmtLimit = $this->getPersistence()->query($limitSql, $paramsValues);
+        $dataLimit = $stmtLimit->fetchAll(PDO::FETCH_COLUMN);
+
+
+        $queryBuilder = $this->getQueryBuilder();
+        $conn = $queryBuilder->getConnection();
+        $queryBuilder->select('delivery_m.delivery_id, delivery_m.delivery_name');
+
+        foreach ($statusesMap as $label => $statusUri) {
+            $queryBuilder->addSelect('count('.$conn->quoteIdentifier('s_'.$label).'.status) as ' . $conn->quoteIdentifier($label));
+        }
+
+        $queryBuilder->addSelect('max('.$conn->quoteIdentifier('last_launch').'.start_time) as ' . $conn->quoteIdentifier(__('Last launch')));
+
+        $queryBuilder->from(self::TABLE_NAME, 'delivery_m');
+
+        $paramsValues = [];
+        $statusNum = 0;
+        foreach ($statusesMap as $label => $statusUri) {
+            $queryBuilder->leftJoin(
+                'delivery_m',
+                self::TABLE_NAME,
+                $conn->quoteIdentifier('s_'.$label),
+                'delivery_m.delivery_execution_id='.$conn->quoteIdentifier('s_'.$label).'.delivery_execution_id and '
+                .$conn->quoteIdentifier('s_'.$label).'.status = :status_uri_'.$statusNum
+            );
+            $paramsValues[':status_uri_'.$statusNum] = $statusUri;
+            $statusNum++;
+        }
+        $queryBuilder->leftJoin(
+            'delivery_m',
+            self::TABLE_NAME,
+            $conn->quoteIdentifier('last_launch'),
+            'delivery_m.delivery_execution_id='.$conn->quoteIdentifier('last_launch').'.delivery_execution_id'
+        );
+
+        if ($dataLimit) {
+            $placeHolders = [];
+            foreach ($dataLimit as $index => $value) {
+                $key = ':in_condition_' . $index;
+                $placeHolders[] = $key;
+                $paramsValues[$key] = $value;
+            }
+            $placeHolders = implode(',', $placeHolders);
+            $queryBuilder->where("delivery_m.delivery_id IN ($placeHolders)");
+        }
+
+        $queryBuilder->groupBy('delivery_m.delivery_id, delivery_m.delivery_name');
+
+        foreach ($statusesMap as $label => $statusUri) {
+            $queryBuilder->addGroupBy($conn->quoteIdentifier('s_'.$label).'.status');
+        }
+
+        $outerQueryBuilder = $this->getQueryBuilder();
+
+        $outerQueryBuilder->select('delivery_name as label, delivery_id');
+
+        foreach ($statusesMap as $label => $statusUri) {
+            $outerQueryBuilder->addSelect('sum('.$conn->quoteIdentifier($label).') as ' . $conn->quoteIdentifier($label));
+        }
+        $outerQueryBuilder->addSelect('max('.$conn->quoteIdentifier(__('Last launch')).') as ' .  $conn->quoteIdentifier(__('Last launch')));
+        $outerQueryBuilder->from('('.$queryBuilder->getSQL().')', 'delivery_statuses');
+        $outerQueryBuilder->groupBy('delivery_id, label');
+        $outerQueryBuilder->orderBy($conn->quoteIdentifier($orderby), $orderdir);
+
+        $sql = $outerQueryBuilder->getSQL();
+
+        $stmt = $this->getPersistence()->query($sql, $paramsValues);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function deleteDeliveryExecutionData(DeliveryExecutionDeleteRequest $request): bool
+    {
+        return $this->delete(
+            $this->getData($request->getDeliveryExecution())
+        );
+    }
+
+    /**
+     * @param $order
+     * @return string
+     */
+    protected function prepareOrderStmt($order): string
+    {
+        $order = explode(',', $order);
+        $result = [];
+        $primaryTableColumns = $this->getPrimaryColumns();
+        foreach ($order as $ruleNum => $orderRule) {
+            preg_match('/([a-zA-Z_][a-zA-Z0-9_]*)\s?(asc|desc)?\s?(string|numeric)?/i', $orderRule, $ruleParts);
+
+            if (!in_array($ruleParts[1], $primaryTableColumns)) {
+                $colName = $ruleParts[1];
+                $this->queryParams[] = $colName;
+            } else {
+                $sortingColumn = $ruleParts[1];
+            }
+
+            $result[] = isset($ruleParts[3]) && $ruleParts[3] === 'numeric'
+                ? sprintf("cast(nullif(%s, '') as decimal) %s", $sortingColumn, $ruleParts[2])
+                : sprintf('%s %s', $sortingColumn, isset($ruleParts[2]) ? $ruleParts[2] : 'ASC');
+        }
+
+        return implode(', ', $result);
+    }
+
+    /**
+     * Load data instead of searching
+     *
+     * @param string $deliveryExecutionId
+     * @return array
+     */
+    private function loadData(string $deliveryExecutionId): array
+    {
+        $qb = $this->getQueryBuilder();
+        $qb->select('*')
+            ->from(self::TABLE_NAME)
+            ->where(self::DELIVERY_EXECUTION_ID.'= :id')
+            ->setParameter('id', $deliveryExecutionId);
+
+        $data = $qb->execute()->fetch(PDO::FETCH_ASSOC);
+
+        if ($data === false) {
+            $data = [];
+        } else {
+            if (isset($data[self::COLUMN_EXTRA_DATA][0])) {
+                $extraData = json_decode($data[self::COLUMN_EXTRA_DATA][0], true);
+                if (json_last_error() === JSON_ERROR_NONE) {
+                    $data = array_merge($data, $extraData);
+                }
+            }
+            unset($data[self::COLUMN_EXTRA_DATA]);
+        }
+
+        return $data;
+    }
+
+    /**
+     * Create new record
+     * @param DeliveryMonitoringDataInterface $deliveryMonitoring
+     * @return boolean whether data is saved
+     * @throws Exception
+     */
+    private function create(DeliveryMonitoringDataInterface $deliveryMonitoring): bool
+    {
+        $data = $deliveryMonitoring->get();
+
+        $primaryTableData = $this->extractPrimaryData($data);
+
+        $extraData = $this->extractKvData($data);
+
+        $types[self::COLUMN_EXTRA_DATA] = ($this->getPlatformName() == 'mysql') ? 'json' : 'jsonb';
+        $primaryTableData[self::COLUMN_EXTRA_DATA] = json_encode($extraData);
+
+        return $this->getPersistence()->insert(self::TABLE_NAME, $primaryTableData, $types) === 1;
+    }
+
+    /**
+     * Update existing record
+     * @param DeliveryMonitoringDataInterface $deliveryMonitoring
+     * @return boolean whether data is saved
+     */
+    private function update(DeliveryMonitoringDataInterface $deliveryMonitoring)
+    {
+        $params = [':delivery_execution_id' => $deliveryMonitoring->get()[self::COLUMN_DELIVERY_EXECUTION_ID]];
+
+        $data = $deliveryMonitoring->get();
+        $extraData = $this->extractKvData($data);
+
+        $primaryTableData = $this->extractPrimaryData($data);
+
+        unset($primaryTableData['delivery_execution_id']);
+        $setClauses = [];
+        foreach ($primaryTableData as $dataKey => $dataValue) {
+            $setClauses[] = sprintf('%s = :%s', $dataKey, $dataKey);
+            $params[sprintf(':%s', $dataKey)] = $dataValue;
+        }
+
+        $setExtraDataClauses = [];
+        $platformName = $this->getPlatformName();
+        foreach ($extraData as $extraDataKey => $extraDataValue) {
+            if ($platformName == 'mysql') {
+                $setExtraDataClauses[] = sprintf('\'$.%s\', :%s', $extraDataKey, $extraDataKey);
+            } else {
+                $setExtraDataClauses[] = sprintf('jsonb_build_object(\'%s\', :%s::jsonb)', $extraDataKey, $extraDataKey);
+                $extraDataValue = json_encode($extraDataValue);
+            }
+            $params[sprintf(':%s', $extraDataKey)] = $extraDataValue;
+        }
+
+        if (!empty($setExtraDataClauses)) {
+            if ($platformName == 'mysql') {
+                $setClauses[] = sprintf(
+                    '%s = json_set(COALESCE(%s, \'{}\'), %s)',
+                    self::COLUMN_EXTRA_DATA, self::COLUMN_EXTRA_DATA, implode(', ', $setExtraDataClauses)
+                );
+            } else {
+                $setClauses[] = sprintf(
+                    '%s = CASE WHEN %s IS NULL THEN %s ELSE %s || %s END',
+                    self::COLUMN_EXTRA_DATA,
+                    self::COLUMN_EXTRA_DATA,
+                    implode(' || ', $setExtraDataClauses),
+                    self::COLUMN_EXTRA_DATA,
+                    implode(' || ', $setExtraDataClauses)
+                );
+            }
+        }
+
+        $setClause = implode(', ', $setClauses);
+
+        $sql = sprintf(
+            'UPDATE %s SET %s WHERE %s  = :delivery_execution_id',
+            self::TABLE_NAME, $setClause, self::COLUMN_DELIVERY_EXECUTION_ID
+        );
+
+        return $this->getPersistence()->exec($sql, $params);
+    }
+
+    /**
+     * Get list of table column names
+     * @return array
+     */
+    private function getPrimaryColumns()
+    {
+        return $this->getOption(self::OPTION_PRIMARY_COLUMNS);
+    }
+
+    /**
+     * @todo cast data to object
+     * @param array $data
+     * @return array
+     */
+    private function extractPrimaryData(array $data)
+    {
+        $result = [];
+        $primaryTableCols = $this->getPrimaryColumns();
+        foreach ($primaryTableCols as $primaryTableCol) {
+            if (isset($data[$primaryTableCol])) {
+                $result[$primaryTableCol] = $data[$primaryTableCol];
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * @param array $data
+     * @return array
+     */
+    private function extractKvData(array $data)
+    {
+        $result = [];
+        $primaryTableCols = $this->getPrimaryColumns();
+        foreach ($data as $key => $val) {
+            if (!in_array($key, $primaryTableCols)) {
+                $result[$key] = $val;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param $condition
+     * @param $parameters
+     * @param $selectClause
+     * @return string
+     */
+    private function prepareCondition($condition, &$parameters)
+    {
+        $whereClause = '';
+
+        //if condition is [ [ key => val ] ] then flatten to [ key => val ]
+        if (is_array($condition) && count($condition) === 1 && is_array(current($condition)) && gettype(array_keys($condition)[0]) == 'integer' ) {
+             $condition = current($condition);
+        }
+
+        if (is_string($condition) && in_array(mb_strtoupper($condition), ['OR', 'AND'])) {
+            $whereClause .= " $condition ";
+        } else if (is_array($condition) && count($condition) > 1) {
+            $whereClause .=  '(';
+            $previousCondition = null;
+            foreach ($condition as $subCondition) {
+                if (is_array($subCondition) && is_array($previousCondition)) {
+                    $whereClause .= 'AND';
+                }
+                $whereClause .=  $this->prepareCondition($subCondition, $parameters);
+                $previousCondition = $subCondition;
+            }
+            $whereClause .=  ')';
+        } else if (is_array($condition) && count($condition) === 1) {
+            $primaryColumns = $this->getPrimaryColumns();
+            $key = array_keys($condition)[0];
+            $value = $condition[$key];
+            $toLower = false;
+
+            if ($value === null) {
+                $op = 'IS NULL';
+            } elseif(is_array($value)){
+                $op = 'IN (' . join(',', array_map(function(){ return '?'; }, $value)) . ')';
+            } elseif (preg_match('/^(?:\s*(<>|<=|>=|<|>|=|LIKE|ILIKE|NOT\sLIKE|NOT\sILIKE))?(.*)$/', $value, $matches)) {
+                if (!empty($matches[1]) && preg_grep('/' . $matches[1] .'/i', ['like','ilike'])) {
+                    $toLower = true;
+                    $op = 'LIKE';
+                } elseif (!empty($matches[1]) && preg_grep('/' . $matches[1] .'/i', ['not like','not ilike'])) {
+                    $toLower = true;
+                    $op = 'NOT LIKE';
+                } else {
+                    $op = $matches[1] ? $matches[1] : '=';
+                }
+                $op .= ' ? ';
+                $value = $toLower ? strtolower($matches[2]) : $matches[2];
+            }
+
+            if (in_array($key, $primaryColumns)) {
+                $whereClause .= $toLower ? " LOWER(t.$key) " : " t.$key ";
+                $whereClause .= $op;
+            } else {
+                if ($this->getPlatformName() == 'mysql') {
+                    $whereClause .= sprintf(' JSON_EXTRACT(t.%s, \'$.%s\') %s ', self::COLUMN_EXTRA_DATA, trim($key), $op);
+                } else {
+                    $whereClause .= sprintf(' t.%s -> \'%s\' %s ', self::COLUMN_EXTRA_DATA, trim($key), $op);
+                    $value = is_array($value) ? $value : [$value];
+                    $value = array_map('json_encode', $value);
+                }
+            }
+
+            if(is_array($value)){
+               $parameters = array_merge($parameters, $value);
+            } else if ($value !== null) {
+                $parameters[] = trim($value);
+            }
+        }
+        return $whereClause;
+    }
+
+    private function getQueryBuilder(): QueryBuilder
+    {
+        return $this->getPersistence()->getPlatForm()->getQueryBuilder();
+    }
+
+    private function getPlatformName(): string
+    {
+        return $this->getPersistence()->getPlatForm()->getName();
+    }
+}

--- a/model/repository/MonitoringRepository.php
+++ b/model/repository/MonitoringRepository.php
@@ -524,7 +524,7 @@ class MonitoringRepository extends ConfigurableService implements DeliveryMonito
 
         $extraData = $this->extractKvData($data);
 
-        $types[self::COLUMN_EXTRA_DATA] = ($this->getPlatformName() == 'mysql') ? 'json' : 'jsonb';
+        $types[self::COLUMN_EXTRA_DATA] = (in_array($this->getPlatformName(), ['mysql','sqlite'])) ? 'json' : 'jsonb';
         $primaryTableData[self::COLUMN_EXTRA_DATA] = json_encode($extraData);
 
         return $this->getPersistence()->insert(self::TABLE_NAME, $primaryTableData, $types) === 1;
@@ -554,7 +554,7 @@ class MonitoringRepository extends ConfigurableService implements DeliveryMonito
         $setExtraDataClauses = [];
         $platformName = $this->getPlatformName();
         foreach ($extraData as $extraDataKey => $extraDataValue) {
-            if ($platformName == 'mysql') {
+            if (in_array($platformName, ['mysql','sqlite'])) {
                 $setExtraDataClauses[] = sprintf('\'$.%s\', :%s', $extraDataKey, $extraDataKey);
             } else {
                 $setExtraDataClauses[] = sprintf('jsonb_build_object(\'%s\', :%s::jsonb)', $extraDataKey, $extraDataKey);
@@ -564,7 +564,7 @@ class MonitoringRepository extends ConfigurableService implements DeliveryMonito
         }
 
         if (!empty($setExtraDataClauses)) {
-            if ($platformName == 'mysql') {
+            if (in_array($platformName, ['mysql','sqlite'])) {
                 $setClauses[] = sprintf(
                     '%s = json_set(COALESCE(%s, \'{}\'), %s)',
                     self::COLUMN_EXTRA_DATA, self::COLUMN_EXTRA_DATA, implode(', ', $setExtraDataClauses)
@@ -690,7 +690,7 @@ class MonitoringRepository extends ConfigurableService implements DeliveryMonito
                 $whereClause .= $toLower ? " LOWER(t.$key) " : " t.$key ";
                 $whereClause .= $op;
             } else {
-                if ($this->getPlatformName() == 'mysql') {
+                if (in_array($this->getPlatformName(), ['mysql','sqlite'])) {
                     $whereClause .= sprintf(' JSON_EXTRACT(t.%s, \'$.%s\') %s ', self::COLUMN_EXTRA_DATA, trim($key), $op);
                 } else {
                     $whereClause .= sprintf(' t.%s -> \'%s\' %s ', self::COLUMN_EXTRA_DATA, trim($key), $op);

--- a/model/repository/MonitoringRepository.php
+++ b/model/repository/MonitoringRepository.php
@@ -21,7 +21,7 @@
 
 declare(strict_types=1);
 
-namespace oat\taoProctoring\model\monitorCache\implementation;
+namespace oat\taoProctoring\model\repository;
 
 use common_exception_NotFound;
 use common_persistence_SqlPersistence;
@@ -37,10 +37,11 @@ use oat\taoProctoring\model\monitorCache\DeliveryMonitoringData as DeliveryMonit
 use oat\oatbox\service\ConfigurableService;
 use oat\generis\model\OntologyAwareTrait;
 use oat\taoProctoring\model\execution\DeliveryExecution as ProctoredDeliveryExecution;
+use oat\taoProctoring\model\monitorCache\implementation\DeliveryMonitoringData;
 use PDO;
 use PDOException;
 
-class SimpleMonitoringStorage extends ConfigurableService implements DeliveryMonitoringService
+class MonitoringRepository extends ConfigurableService implements DeliveryMonitoringService
 {
     use OntologyAwareTrait;
 

--- a/model/repository/MonitoringRepository.php
+++ b/model/repository/MonitoringRepository.php
@@ -292,7 +292,7 @@ class MonitoringRepository extends ConfigurableService implements DeliveryMonito
     }
 
     /**
-     * @todo extract this method to another service with statistic responsabilities
+     * @todo extract this method to another service with statistic responsibilities
      * @todo query of 150 lines, erf
      *
      * @param int $limit

--- a/scripts/install/SetupDeliveryMonitoring.php
+++ b/scripts/install/SetupDeliveryMonitoring.php
@@ -46,9 +46,10 @@ class SetupDeliveryMonitoring extends InstallAction
             $this->propagate($service);
         }
 
-        call_user_func(new DbSetup(), ['persistence' => $service->getPersistence()]);
+        $dbSetup = new DbSetup();
+        $dbSetup->generateTable($service->getPersistence());
 
-        $service->setOption(MonitoringRepository::OPTION_PRIMARY_COLUMNS, DbSetup::getPrimaryColumns());
+        $service->setOption(MonitoringRepository::OPTION_PRIMARY_COLUMNS, $dbSetup->getPrimaryColumns());
         $this->registerService(MonitoringRepository::SERVICE_ID, $service);
     }
 }

--- a/scripts/install/SetupDeliveryMonitoring.php
+++ b/scripts/install/SetupDeliveryMonitoring.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -14,44 +15,43 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016 (original work) Open Assessment Technologies SA;
- *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
  *
  */
+
+declare(strict_types=1);
 
 namespace oat\taoProctoring\scripts\install;
 
 use oat\oatbox\extension\InstallAction;
 use oat\oatbox\service\ServiceNotFoundException;
+use oat\taoProctoring\model\monitorCache\DeliveryMonitoringService;
+use oat\taoProctoring\model\repository\MonitoringRepository;
 use oat\taoProctoring\scripts\install\db\DbSetup;
-use oat\taoProctoring\model\monitorCache\implementation\MonitorCacheService;
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use Zend\ServiceManager\ServiceLocatorAwareTrait;
 
 /**
- * Setup the tables and the service to cache
- * delivery data to allow monitoring
+ * Setup the tables and the service to enable delivery data to allow monitoring
  */
-class SetupDeliveryMonitoring extends InstallAction
+class SetupDeliveryMonitoring extends InstallAction implements ServiceLocatorAwareInterface
 {
-    /**
-     * @param $params
-     */
+    use ServiceLocatorAwareTrait;
+
     public function __invoke($params)
     {
         try {
-            $service = $this->getServiceManager()->get(MonitorCacheService::SERVICE_ID);
+            $service = $this->getServiceLocator()->get(DeliveryMonitoringService::SERVICE_ID);
         } catch (ServiceNotFoundException $exception) {
-            $service = new MonitorCacheService(array(
-                MonitorCacheService::OPTION_PERSISTENCE => 'default',
-                MonitorCacheService::OPTION_USE_UPDATE_MULTIPLE => false
+            $service = new MonitoringRepository(array(
+                MonitoringRepository::OPTION_PERSISTENCE => 'default',
+                MonitoringRepository::OPTION_USE_UPDATE_MULTIPLE => false
             ));
-            $service->setServiceManager($this->getServiceManager());
         }
-        $persistence = $service->getPersistence();
 
-        DbSetup::generateTable($persistence);
+        call_user_func(new DbSetup(), ['persistence' => $service->getPersistence()]);
 
-        $service->setOption(MonitorCacheService::OPTION_PRIMARY_COLUMNS, DbSetup::getPrimaryColumns());
-        $this->registerService(MonitorCacheService::SERVICE_ID, $service);
+        $service->setOption(MonitoringRepository::OPTION_PRIMARY_COLUMNS, DbSetup::getPrimaryColumns());
+        $this->registerService(MonitoringRepository::SERVICE_ID, $service);
     }
 }
-

--- a/scripts/install/SetupDeliveryMonitoring.php
+++ b/scripts/install/SetupDeliveryMonitoring.php
@@ -28,20 +28,16 @@ use oat\oatbox\service\ServiceNotFoundException;
 use oat\taoProctoring\model\monitorCache\DeliveryMonitoringService;
 use oat\taoProctoring\model\repository\MonitoringRepository;
 use oat\taoProctoring\scripts\install\db\DbSetup;
-use Zend\ServiceManager\ServiceLocatorAwareInterface;
-use Zend\ServiceManager\ServiceLocatorAwareTrait;
 
 /**
  * Setup the tables and the service to enable delivery data to allow monitoring
  */
-class SetupDeliveryMonitoring extends InstallAction implements ServiceLocatorAwareInterface
+class SetupDeliveryMonitoring extends InstallAction
 {
-    use ServiceLocatorAwareTrait;
-
     public function __invoke($params)
     {
         try {
-            $service = $this->getServiceLocator()->get(DeliveryMonitoringService::SERVICE_ID);
+            $service = $this->getServiceManager()->get(DeliveryMonitoringService::SERVICE_ID);
         } catch (ServiceNotFoundException $exception) {
             $service = new MonitoringRepository(array(
                 MonitoringRepository::OPTION_PERSISTENCE => 'default',

--- a/scripts/install/SetupDeliveryMonitoring.php
+++ b/scripts/install/SetupDeliveryMonitoring.php
@@ -47,6 +47,7 @@ class SetupDeliveryMonitoring extends InstallAction implements ServiceLocatorAwa
                 MonitoringRepository::OPTION_PERSISTENCE => 'default',
                 MonitoringRepository::OPTION_USE_UPDATE_MULTIPLE => false
             ));
+            $this->propagate($service);
         }
 
         call_user_func(new DbSetup(), ['persistence' => $service->getPersistence()]);

--- a/scripts/install/SetupProctoringEventListeners.php
+++ b/scripts/install/SetupProctoringEventListeners.php
@@ -14,10 +14,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016 (original work) Open Assessment Technologies SA;
- *
+ * Copyright (c) 2016-2021 (original work) Open Assessment Technologies SA;
  *
  */
+
 declare(strict_types=1);
 
 namespace oat\taoProctoring\scripts\install;
@@ -40,16 +40,8 @@ use oat\taoEventLog\model\eventLog\LoggerService;
 use oat\taoDeliveryRdf\model\event\DeliveryUpdatedEvent;
 use oat\taoDeliveryRdf\model\event\DeliveryCreatedEvent;
 
-/**
- * Class RegisterSessionStateListener
- * @package oat\taoProctoring\scripts\install
- * @author Aleh Hutnikau, <hutnikau@1pt.com>
- */
 class SetupProctoringEventListeners extends InstallAction
 {
-    /**
-     * @param $params
-     */
     public function __invoke($params)
     {
         $this->registerEvent(DeliveryExecutionState::class, [MonitoringListenerInterface::SERVICE_ID, 'executionStateChanged']);
@@ -73,4 +65,3 @@ class SetupProctoringEventListeners extends InstallAction
         $this->registerEvent(DeliveryExecutionTimerAdjusted::class, [DeliveryLogTimerAdjustedEventListener::class, 'logTimeAdjustment']);
     }
 }
-

--- a/scripts/install/SetupProctoringEventListeners.php
+++ b/scripts/install/SetupProctoringEventListeners.php
@@ -22,19 +22,15 @@ declare(strict_types=1);
 
 namespace oat\taoProctoring\scripts\install;
 
-use oat\oatbox\event\EventManager;
 use oat\oatbox\extension\InstallAction;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionCreated;
 use oat\taoProctoring\model\delivery\DeliverySyncService;
 use oat\taoProctoring\model\deliveryLog\listener\DeliveryLogTimerAdjustedEventListener;
 use oat\taoProctoring\model\event\DeliveryExecutionTimerAdjusted;
 use oat\taoProctoring\model\listener\MonitoringListenerInterface;
-use oat\taoProctoring\scripts\tools\MonitoringExtraFieldConfigurationMigration;
 use oat\taoTests\models\event\TestExecutionPausedEvent;
-use oat\taoProctoring\model\implementation\DeliveryExecutionStateService;
 use oat\taoTests\models\event\TestChangedEvent;
 use oat\taoQtiTest\models\event\QtiTestStateChangeEvent;
-use oat\taoProctoring\model\monitorCache\DeliveryMonitoringService;
 use oat\tao\model\event\MetadataModified;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState;
 use oat\taoProctoring\helpers\DeliveryHelper;

--- a/scripts/install/db/DbSetup.php
+++ b/scripts/install/db/DbSetup.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -14,70 +15,76 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015 (original work) Open Assessment Technologies SA;
- *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
  *
  */
+
+declare(strict_types=1);
+
 namespace oat\taoProctoring\scripts\install\db;
 
 use Doctrine\DBAL\Schema\SchemaException;
-use Doctrine\DBAL\Types\Type;
-use oat\taoProctoring\model\monitorCache\implementation\MonitoringStorage;
 use common_Logger;
-use oat\taoProctoring\model\monitorCache\implementation\SimpleMonitoringStorage;
+use oat\oatbox\action\Action;
+use oat\oatbox\reporting\Report;
+use oat\taoProctoring\model\repository\MonitoringRepository;
 
-class DbSetup {
-
-    public static function generateTable(\common_persistence_SqlPersistence $persistence)
+class DbSetup implements Action
+{
+    public function __invoke($params)
     {
+        if (!isset($params['persistence'])) {
+            return new Report(Report::TYPE_ERROR, 'Missing required parameter `persistence`.');
+        }
+        $persistence = $params['persistence'];
 
         $schemaManager = $persistence->getDriver()->getSchemaManager();
         $schema = $schemaManager->createSchema();
         $fromSchema = clone $schema;
 
         try {
-            $tableLog = $schema->createTable(MonitoringStorage::TABLE_NAME);
+            $tableLog = $schema->createTable(MonitoringRepository::TABLE_NAME);
             $tableLog->addOption('engine', 'InnoDB');
-            $tableLog->addColumn(MonitoringStorage::COLUMN_DELIVERY_EXECUTION_ID, "string", array("notnull" => true, "length" => 255));
-            $tableLog->addColumn(MonitoringStorage::COLUMN_STATUS, "string", array("notnull" => true, "length" => 255));
-            $tableLog->addColumn(MonitoringStorage::COLUMN_CURRENT_ASSESSMENT_ITEM, "string", array("notnull" => false, "length" => 255));
-            $tableLog->addColumn(MonitoringStorage::COLUMN_TEST_TAKER, "string", array("notnull" => false, "length" => 255));
-            $tableLog->addColumn(MonitoringStorage::COLUMN_AUTHORIZED_BY, "string", array("notnull" => false, "length" => 255));
-            $tableLog->addColumn(MonitoringStorage::COLUMN_START_TIME, "string", array("notnull" => false, "length" => 255));
-            $tableLog->addColumn(MonitoringStorage::COLUMN_END_TIME, "string", array("notnull" => false, "length" => 255));
-            $tableLog->addColumn(MonitoringStorage::COLUMN_TEST_TAKER_FIRST_NAME, "string", array("notnull" => false, "length" => 255));
-            $tableLog->addColumn(MonitoringStorage::COLUMN_TEST_TAKER_LAST_NAME, "string", array("notnull" => false, "length" => 255));
-            $tableLog->addColumn(MonitoringStorage::DELIVERY_ID, "text", array("notnull" => false));
-            $tableLog->addColumn(MonitoringStorage::DELIVERY_NAME, "text", array("notnull" => false));
-            $tableLog->addColumn(MonitoringStorage::LAST_TEST_TAKER_ACTIVITY, "string", array("notnull" => false, "length" => 255));
-            $tableLog->addColumn(MonitoringStorage::REMAINING_TIME, "string", array("notnull" => false, "length" => 255));
-            $tableLog->addColumn(MonitoringStorage::EXTENDED_TIME, "string", array("notnull" => false, "length" => 255));
-            $tableLog->addColumn(MonitoringStorage::EXTRA_TIME, "string", array("notnull" => false, "length" => 255));
-            $tableLog->addColumn(MonitoringStorage::CONSUMED_EXTRA_TIME, "string", array("notnull" => false, "length" => 255));
-            $tableLog->addColumn(MonitoringStorage::ITEM_DURATION, "string", array("notnull" => false, "length" => 32));
-            $tableLog->addColumn(MonitoringStorage::STORED_ITEM_DURATION, "string", array("notnull" => false, "length" => 32));
+            $tableLog->addColumn(MonitoringRepository::COLUMN_DELIVERY_EXECUTION_ID, "string", array("notnull" => true, "length" => 255));
+            $tableLog->addColumn(MonitoringRepository::COLUMN_STATUS, "string", array("notnull" => true, "length" => 255));
+            $tableLog->addColumn(MonitoringRepository::COLUMN_CURRENT_ASSESSMENT_ITEM, "string", array("notnull" => false, "length" => 255));
+            $tableLog->addColumn(MonitoringRepository::COLUMN_TEST_TAKER, "string", array("notnull" => false, "length" => 255));
+            $tableLog->addColumn(MonitoringRepository::COLUMN_AUTHORIZED_BY, "string", array("notnull" => false, "length" => 255));
+            $tableLog->addColumn(MonitoringRepository::COLUMN_START_TIME, "string", array("notnull" => false, "length" => 255));
+            $tableLog->addColumn(MonitoringRepository::COLUMN_END_TIME, "string", array("notnull" => false, "length" => 255));
+            $tableLog->addColumn(MonitoringRepository::COLUMN_TEST_TAKER_FIRST_NAME, "string", array("notnull" => false, "length" => 255));
+            $tableLog->addColumn(MonitoringRepository::COLUMN_TEST_TAKER_LAST_NAME, "string", array("notnull" => false, "length" => 255));
+            $tableLog->addColumn(MonitoringRepository::DELIVERY_ID, "text", array("notnull" => false));
+            $tableLog->addColumn(MonitoringRepository::DELIVERY_NAME, "text", array("notnull" => false));
+            $tableLog->addColumn(MonitoringRepository::LAST_TEST_TAKER_ACTIVITY, "string", array("notnull" => false, "length" => 255));
+            $tableLog->addColumn(MonitoringRepository::REMAINING_TIME, "string", array("notnull" => false, "length" => 255));
+            $tableLog->addColumn(MonitoringRepository::EXTENDED_TIME, "string", array("notnull" => false, "length" => 255));
+            $tableLog->addColumn(MonitoringRepository::EXTRA_TIME, "string", array("notnull" => false, "length" => 255));
+            $tableLog->addColumn(MonitoringRepository::CONSUMED_EXTRA_TIME, "string", array("notnull" => false, "length" => 255));
+            $tableLog->addColumn(MonitoringRepository::ITEM_DURATION, "string", array("notnull" => false, "length" => 32));
+            $tableLog->addColumn(MonitoringRepository::STORED_ITEM_DURATION, "string", array("notnull" => false, "length" => 32));
 
             if ($persistence->getPlatForm()->getName() == 'mysql') {
-                $tableLog->addColumn(SimpleMonitoringStorage::COLUMN_EXTRA_DATA, 'json', array("notnull" => false));
+                $tableLog->addColumn(MonitoringRepository::COLUMN_EXTRA_DATA, 'json', array("notnull" => false));
             }
 
-            $tableLog->setPrimaryKey(array(MonitoringStorage::COLUMN_DELIVERY_EXECUTION_ID));
+            $tableLog->setPrimaryKey(array(MonitoringRepository::COLUMN_DELIVERY_EXECUTION_ID));
 
             $tableLog->addIndex(
-                array(MonitoringStorage::COLUMN_DELIVERY_EXECUTION_ID),
-                'IDX_' . MonitoringStorage::COLUMN_DELIVERY_EXECUTION_ID . '_' . MonitoringStorage::COLUMN_DELIVERY_EXECUTION_ID
+                array(MonitoringRepository::COLUMN_DELIVERY_EXECUTION_ID),
+                'IDX_' . MonitoringRepository::COLUMN_DELIVERY_EXECUTION_ID . '_' . MonitoringRepository::COLUMN_DELIVERY_EXECUTION_ID
             );
             $tableLog->addIndex(
-                array(MonitoringStorage::COLUMN_START_TIME),
-                'IDX_' . MonitoringStorage::TABLE_NAME . '_' . MonitoringStorage::COLUMN_START_TIME
+                array(MonitoringRepository::COLUMN_START_TIME),
+                'IDX_' . MonitoringRepository::TABLE_NAME . '_' . MonitoringRepository::COLUMN_START_TIME
             );
             $tableLog->addIndex(
-                array(MonitoringStorage::COLUMN_END_TIME),
-                'IDX_' . MonitoringStorage::TABLE_NAME . '_' . MonitoringStorage::COLUMN_END_TIME
+                array(MonitoringRepository::COLUMN_END_TIME),
+                'IDX_' . MonitoringRepository::TABLE_NAME . '_' . MonitoringRepository::COLUMN_END_TIME
             );
             $tableLog->addUniqueIndex(
-                array(MonitoringStorage::COLUMN_DELIVERY_EXECUTION_ID),
-                'IDX_' . MonitoringStorage::TABLE_NAME . '_' . MonitoringStorage::COLUMN_DELIVERY_EXECUTION_ID . '_UNIQUE'
+                array(MonitoringRepository::COLUMN_DELIVERY_EXECUTION_ID),
+                'IDX_' . MonitoringRepository::TABLE_NAME . '_' . MonitoringRepository::COLUMN_DELIVERY_EXECUTION_ID . '_UNIQUE'
             );
 
         } catch(SchemaException $e) {
@@ -89,8 +96,8 @@ class DbSetup {
         if ($persistence->getPlatForm()->getName() == 'postgresql') {
             $queries[] = sprintf(
                 'ALTER TABLE %s ADD COLUMN %s jsonb',
-                SimpleMonitoringStorage::TABLE_NAME,
-                SimpleMonitoringStorage::COLUMN_EXTRA_DATA
+                MonitoringRepository::TABLE_NAME,
+                MonitoringRepository::COLUMN_EXTRA_DATA
             );
         }
 
@@ -101,30 +108,28 @@ class DbSetup {
 
     /**
      * Returns a list of columns stored in the primary table
-     *
-     * @return array column identifiers
      */
-    public static function getPrimaryColumns()
+    public function getPrimaryColumns(): array
     {
         return [
-            MonitoringStorage::COLUMN_DELIVERY_EXECUTION_ID,
-            MonitoringStorage::COLUMN_STATUS,
-            MonitoringStorage::COLUMN_CURRENT_ASSESSMENT_ITEM,
-            MonitoringStorage::COLUMN_TEST_TAKER,
-            MonitoringStorage::COLUMN_AUTHORIZED_BY,
-            MonitoringStorage::COLUMN_START_TIME,
-            MonitoringStorage::COLUMN_END_TIME,
-            MonitoringStorage::COLUMN_TEST_TAKER_FIRST_NAME,
-            MonitoringStorage::COLUMN_TEST_TAKER_LAST_NAME,
-            MonitoringStorage::DELIVERY_ID,
-            MonitoringStorage::DELIVERY_NAME,
-            MonitoringStorage::LAST_TEST_TAKER_ACTIVITY,
-            MonitoringStorage::REMAINING_TIME,
-            MonitoringStorage::EXTENDED_TIME,
-            MonitoringStorage::EXTRA_TIME,
-            MonitoringStorage::CONSUMED_EXTRA_TIME,
-            MonitoringStorage::ITEM_DURATION,
-            MonitoringStorage::STORED_ITEM_DURATION,
+            MonitoringRepository::COLUMN_DELIVERY_EXECUTION_ID,
+            MonitoringRepository::COLUMN_STATUS,
+            MonitoringRepository::COLUMN_CURRENT_ASSESSMENT_ITEM,
+            MonitoringRepository::COLUMN_TEST_TAKER,
+            MonitoringRepository::COLUMN_AUTHORIZED_BY,
+            MonitoringRepository::COLUMN_START_TIME,
+            MonitoringRepository::COLUMN_END_TIME,
+            MonitoringRepository::COLUMN_TEST_TAKER_FIRST_NAME,
+            MonitoringRepository::COLUMN_TEST_TAKER_LAST_NAME,
+            MonitoringRepository::DELIVERY_ID,
+            MonitoringRepository::DELIVERY_NAME,
+            MonitoringRepository::LAST_TEST_TAKER_ACTIVITY,
+            MonitoringRepository::REMAINING_TIME,
+            MonitoringRepository::EXTENDED_TIME,
+            MonitoringRepository::EXTRA_TIME,
+            MonitoringRepository::CONSUMED_EXTRA_TIME,
+            MonitoringRepository::ITEM_DURATION,
+            MonitoringRepository::STORED_ITEM_DURATION,
         ];
     }
 }

--- a/scripts/install/db/DbSetup.php
+++ b/scripts/install/db/DbSetup.php
@@ -23,21 +23,15 @@ declare(strict_types=1);
 
 namespace oat\taoProctoring\scripts\install\db;
 
+use common_persistence_SqlPersistence;
 use Doctrine\DBAL\Schema\SchemaException;
 use common_Logger;
-use oat\oatbox\action\Action;
-use oat\oatbox\reporting\Report;
 use oat\taoProctoring\model\repository\MonitoringRepository;
 
-class DbSetup implements Action
+class DbSetup
 {
-    public function __invoke($params)
+    public function generateTable(common_persistence_SqlPersistence $persistence)
     {
-        if (!isset($params['persistence'])) {
-            return new Report(Report::TYPE_ERROR, 'Missing required parameter `persistence`.');
-        }
-        $persistence = $params['persistence'];
-
         $schemaManager = $persistence->getDriver()->getSchemaManager();
         $schema = $schemaManager->createSchema();
         $fromSchema = clone $schema;
@@ -64,7 +58,7 @@ class DbSetup implements Action
             $tableLog->addColumn(MonitoringRepository::ITEM_DURATION, "string", array("notnull" => false, "length" => 32));
             $tableLog->addColumn(MonitoringRepository::STORED_ITEM_DURATION, "string", array("notnull" => false, "length" => 32));
 
-            if ($persistence->getPlatForm()->getName() == 'mysql') {
+            if (in_array($persistence->getPlatForm()->getName(), ['mysql','sqlite'])) {
                 $tableLog->addColumn(MonitoringRepository::COLUMN_EXTRA_DATA, 'json', array("notnull" => false));
             }
 

--- a/scripts/tools/KvMonitoringMigration.php
+++ b/scripts/tools/KvMonitoringMigration.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -21,15 +22,17 @@
 
 namespace oat\taoProctoring\scripts\tools;
 
-
 use oat\oatbox\extension\script\ScriptAction;
 use common_report_Report as Report;
 use oat\taoProctoring\model\monitorCache\DeliveryMonitoringService;
 use oat\taoProctoring\model\monitorCache\implementation\MonitoringStorage;
 
+
+/**
+ * @deprecated
+ */
 class KvMonitoringMigration extends ScriptAction
 {
-
     protected function provideOptions()
     {
         return [

--- a/scripts/tools/MonitoringExtraFieldConfigurationMigration.php
+++ b/scripts/tools/MonitoringExtraFieldConfigurationMigration.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoProctoring\scripts\tools;
+
+use oat\oatbox\event\EventManager;
+use oat\oatbox\extension\script\ScriptAction;
+use oat\oatbox\reporting\Report;
+use oat\tao\model\event\MetadataModified;
+use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionCreated;
+use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState;
+use oat\taoProctoring\model\authorization\AuthorizationGranted;
+use oat\taoProctoring\model\implementation\DeliveryExecutionStateService;
+use oat\taoProctoring\model\listener\MonitoringListenerInterface;
+use oat\taoProctoring\model\monitorCache\DeliveryMonitoringService;
+use oat\taoProctoring\model\repository\MonitoringRepository;
+use oat\taoQtiTest\models\event\QtiTestStateChangeEvent;
+use oat\taoTests\models\event\TestChangedEvent;
+use oat\taoTests\models\event\TestExecutionPausedEvent;
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use Zend\ServiceManager\ServiceLocatorAwareTrait;
+
+class MonitoringExtraFieldConfigurationMigration extends ScriptAction implements ServiceLocatorAwareInterface
+{
+    use ServiceLocatorAwareTrait;
+
+    protected function provideOptions()
+    {
+        return [];
+    }
+
+    protected function provideDescription()
+    {
+        return 'Migrate services and events to enable storage improvement for proctoring monitoring.';
+    }
+
+    protected function run()
+    {
+        $this->migrateEvents();;
+
+        $this->registerMonitoringRepository();
+
+        $report = new Report(Report::TYPE_SUCCESS, 'Events and services are now configured to use new data schema');
+        $report->add(
+            new Report(
+                Report::TYPE_INFO,
+                'If you have delivery executions, you should migrate them via: ' . PHP_EOL .
+                '`php index.php \'\oat\taoProctoring\scripts\tools\MonitoringExtraFieldMigration\' -h`'
+            )
+        );
+
+        return $report;
+    }
+
+    private function migrateEvents(): void
+    {
+        $eventManager = $this->getServiceLocator()->get(EventManager::SERVICE_ID);
+
+        $this->detachLegacyEvents($eventManager);
+        $this->attachNewEvents($eventManager);
+
+        $this->registerService(EventManager::SERVICE_ID, $eventManager);
+    }
+
+    private function detachLegacyEvents(EventManager $eventManager): void
+    {
+        $eventManager->detach(DeliveryExecutionState::class, [DeliveryMonitoringService::SERVICE_ID, 'executionStateChanged']);
+        $eventManager->detach(DeliveryExecutionCreated::class, [DeliveryMonitoringService::SERVICE_ID, 'executionCreated']);
+        $eventManager->detach(MetadataModified::class, [DeliveryMonitoringService::SERVICE_ID, 'deliveryLabelChanged']);
+        $eventManager->detach(TestChangedEvent::EVENT_NAME, [DeliveryMonitoringService::SERVICE_ID, 'testStateChanged']);
+        $eventManager->detach(QtiTestStateChangeEvent::EVENT_NAME, [DeliveryMonitoringService::SERVICE_ID, 'qtiTestStatusChanged']);
+        $eventManager->detach(AuthorizationGranted::EVENT_NAME, [DeliveryMonitoringService::SERVICE_ID, 'deliveryAuthorized']);
+        $eventManager->detach(TestExecutionPausedEvent::class, [DeliveryExecutionStateService::SERVICE_ID, 'catchSessionPause']);
+    }
+
+    private function attachNewEvents(EventManager $eventManager): void
+    {
+        $eventManager->attach(DeliveryExecutionState::class, [MonitoringListenerInterface::SERVICE_ID, 'executionStateChanged']);
+        $eventManager->attach(DeliveryExecutionCreated::class, [MonitoringListenerInterface::SERVICE_ID, 'executionCreated']);
+        $eventManager->attach(MetadataModified::class, [MonitoringListenerInterface::SERVICE_ID, 'deliveryLabelChanged']);
+        $eventManager->attach(TestChangedEvent::EVENT_NAME, [MonitoringListenerInterface::SERVICE_ID, 'testStateChanged']);
+        $eventManager->attach(QtiTestStateChangeEvent::EVENT_NAME, [MonitoringListenerInterface::SERVICE_ID, 'qtiTestStatusChanged']);
+        $eventManager->attach(AuthorizationGranted::EVENT_NAME, [MonitoringListenerInterface::SERVICE_ID, 'deliveryAuthorized']);
+        $eventManager->attach(TestExecutionPausedEvent::class, [MonitoringListenerInterface::SERVICE_ID, 'catchSessionPause']);
+    }
+
+    private function registerMonitoringRepository(): void
+    {
+        $monitoringStorage = $this->getServiceLocator()->get(DeliveryMonitoringService::SERVICE_ID);
+        if (is_a($monitoringStorage, 'oat\taoProctoring\model\monitorCache\implementation\MonitorCacheService', true)) {
+            $options = $monitoringStorage->getOptions();
+            $this->registerService(DeliveryMonitoringService::SERVICE_ID, new MonitoringRepository($options));
+        }
+    }
+}

--- a/scripts/tools/MonitoringExtraFieldConfigurationMigration.php
+++ b/scripts/tools/MonitoringExtraFieldConfigurationMigration.php
@@ -65,7 +65,8 @@ class MonitoringExtraFieldConfigurationMigration extends ScriptAction implements
             new Report(
                 Report::TYPE_INFO,
                 'If you have delivery executions, you should migrate them via: ' . PHP_EOL .
-                '`php index.php \'\oat\taoProctoring\scripts\tools\MonitoringExtraFieldMigration\' -h`'
+                '`php index.php \'\oat\taoProctoring\scripts\tools\MonitoringExtraFieldMigration\' -h`' . PHP_EOL .
+                'This script can take time depending of number of delivery execution to migrate'
             )
         );
 

--- a/scripts/tools/MonitoringExtraFieldMigration.php
+++ b/scripts/tools/MonitoringExtraFieldMigration.php
@@ -28,12 +28,12 @@ use oat\oatbox\extension\script\ScriptAction;
 use common_report_Report as Report;
 use oat\taoProctoring\model\monitorCache\DeliveryMonitoringData;
 use oat\taoProctoring\model\monitorCache\DeliveryMonitoringService;
-use oat\taoProctoring\model\monitorCache\implementation\SimpleMonitoringStorage;
+use oat\taoProctoring\model\repository\MonitoringRepository;
 use PDO;
 
 class MonitoringExtraFieldMigration extends ScriptAction
 {
-    /** @var SimpleMonitoringStorage */
+    /** @var MonitoringRepository */
     private $monitoringService;
 
     /** @var int */
@@ -130,8 +130,8 @@ class MonitoringExtraFieldMigration extends ScriptAction
      */
     private function validateMigrationCanBeDone(): void
     {
-        if (!$this->monitoringService instanceof SimpleMonitoringStorage) {
-            throw new Exception('DeliveryMonitoringService is not implementing SimpleMonitoringStorage. Migration aborted');
+        if (!$this->monitoringService instanceof MonitoringRepository) {
+            throw new Exception('DeliveryMonitoringService is not implementing MonitoringRepository. Migration aborted');
         }
 
         $table = $this->monitoringService
@@ -139,10 +139,10 @@ class MonitoringExtraFieldMigration extends ScriptAction
             ->getDriver()
             ->getSchemaManager()
             ->createSchema()
-            ->getTable(SimpleMonitoringStorage::TABLE_NAME);
+            ->getTable(MonitoringRepository::TABLE_NAME);
 
-        if (!$table->hasColumn(SimpleMonitoringStorage::COLUMN_EXTRA_DATA)) {
-            throw new Exception(sprintf('Column %s does not exist. Migration aborted', SimpleMonitoringStorage::COLUMN_EXTRA_DATA));
+        if (!$table->hasColumn(MonitoringRepository::COLUMN_EXTRA_DATA)) {
+            throw new Exception(sprintf('Column %s does not exist. Migration aborted', MonitoringRepository::COLUMN_EXTRA_DATA));
         }
     }
 

--- a/scripts/tools/MonitoringExtraFieldMigration.php
+++ b/scripts/tools/MonitoringExtraFieldMigration.php
@@ -1,0 +1,246 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoProctoring\scripts\tools;
+
+use Exception;
+use oat\oatbox\extension\script\ScriptAction;
+use common_report_Report as Report;
+use oat\taoProctoring\model\monitorCache\DeliveryMonitoringData;
+use oat\taoProctoring\model\monitorCache\DeliveryMonitoringService;
+use oat\taoProctoring\model\monitorCache\implementation\SimpleMonitoringStorage;
+use PDO;
+
+class MonitoringExtraFieldMigration extends ScriptAction
+{
+    /** @var SimpleMonitoringStorage */
+    private $monitoringService;
+
+    /** @var int */
+    private $updated = 0;
+
+    /** @var int */
+    private $deleted = 0;
+
+    protected function provideOptions()
+    {
+        return [
+            'wet-run' => [
+                'flag' => true,
+                'prefix' => 'w',
+                'longPrefix' => 'wet-run',
+                'description' => 'Use this option to persist data. Default is dry-run mode'
+            ],
+
+            'chunkSize' => [
+                'prefix' => 'c',
+                'defaultValue' => 100,
+                'longPrefix' => 'chunk-size',
+                'cast' => 'integer',
+                'required' => false,
+                'description' => 'Number of delivery_execution migrated processed by iteration.'
+            ],
+
+            'deleteKv' => [
+                'prefix' => 'd',
+                'flag' => true,
+                'longPrefix' => 'deleteKv',
+                'defaultValue' => 0,
+                'description' => 'Indicate if the script should remove migrated data.'
+            ],
+        ];
+    }
+
+    protected function provideDescription()
+    {
+        return 'This tools take care about KV monitoring data migration to the relational table as extra_data column';
+    }
+
+    protected function run()
+    {
+        $this->monitoringService = $this->getServiceLocator()->get(DeliveryMonitoringService::SERVICE_ID);
+
+        try {
+            $this->validateMigrationCanBeDone();
+        } catch (Exception $e) {
+            return Report::createFailure(sprintf('Enable to perform migration with error: %s', $e->getMessage()));
+        }
+
+        $count = $this->monitoringService->count();
+        $chunk = (int) ceil($count / $this->getOption('chunkSize'));
+
+        $this->printMigrationScriptOptions($count, $chunk);
+
+        $offset = 0;
+
+        try {
+            for ($i = 0; $i < $chunk; $i++) {
+                $deliveryExecutions = $this->findDeliveryExecutionsByChunk($offset);
+
+                foreach ($deliveryExecutions as $deliveryExecution) {
+                    $kvData = $this->fetchDeliveryExecutionExtraData($deliveryExecution);
+
+                    $this->migrateDeliveryExecutionKvDataToExtraColumn($deliveryExecution);
+
+                    $this->deleteDeliveryExecutionKvData($deliveryExecution, $kvData);
+                }
+            }
+        } catch (Exception $e) {
+            return new Report(Report::TYPE_ERROR, $e->getMessage());
+        }
+
+        return $this->createScriptReport();
+    }
+
+    protected function provideUsage()
+    {
+        // Overriding this method is option. Simply describe which option prefixes have to
+        // to be used in order to display the usage of the script to end user.
+        return [
+            'prefix' => 'h',
+            'longPrefix' => 'help',
+            'description' => 'Prints a help statement'
+        ];
+    }
+
+    /**
+     * Check if service is already configured to use JSON column and if column `extra_field` exists
+     *
+     * @throws Exception
+     */
+    private function validateMigrationCanBeDone(): void
+    {
+        if (!$this->monitoringService instanceof SimpleMonitoringStorage) {
+            throw new Exception('DeliveryMonitoringService is not implementing SimpleMonitoringStorage. Migration aborted');
+        }
+
+        $table = $this->monitoringService
+            ->getPersistence()
+            ->getDriver()
+            ->getSchemaManager()
+            ->createSchema()
+            ->getTable(SimpleMonitoringStorage::TABLE_NAME);
+
+        if (!$table->hasColumn(SimpleMonitoringStorage::COLUMN_EXTRA_DATA)) {
+            throw new Exception(sprintf('Column %s does not exist. Migration aborted', SimpleMonitoringStorage::COLUMN_EXTRA_DATA));
+        }
+    }
+
+    private function printMigrationScriptOptions(int $countOfDeliveryExecution, int $chunk) :void
+    {
+        echo 'Script options: ' . PHP_EOL;
+        echo sprintf(' - DRY RUN mode: %s', $this->getOption('wet-run') ? 'no' : 'yes') . PHP_EOL;
+        echo sprintf(' - Delete KV data: %s', $this->getOption('deleteKv') ? 'yes' : 'no') . PHP_EOL;
+        echo sprintf(' - Number of delivery executions found: %s', $countOfDeliveryExecution) . PHP_EOL;
+        echo sprintf(' - Chunk size: %s', $this->getOption('chunkSize')) . PHP_EOL;
+        echo sprintf(' - Number of iteration: %s', $chunk) . PHP_EOL;
+    }
+
+    private function findDeliveryExecutionsByChunk(int &$offset): array
+    {
+        $chunkSize = $this->getOption('chunkSize');
+
+        $options = [
+            'limit' => $chunkSize,
+            'offset' => $offset,
+        ];
+
+        $deliveryExecutions = $this->monitoringService->find([], $options);
+
+        if (!$this->getOption('deleteKv') || !$this->getOption('wet-run')) {
+            $offset += $chunkSize;
+        }
+
+        // Moving percentage
+        echo sprintf('%s delivery executions fetched.', count($deliveryExecutions)) . PHP_EOL;
+
+        return $deliveryExecutions;
+    }
+
+    private function fetchDeliveryExecutionExtraData(DeliveryMonitoringData $deliveryExecution): array
+    {
+        $stmt = $this->monitoringService->getPersistence()->query(
+            'SELECT monitoring_key, monitoring_value FROM kv_delivery_monitoring WHERE parent_id = ?',
+            [
+                $deliveryExecution->get()[DeliveryMonitoringService::DELIVERY_EXECUTION_ID]
+            ]
+        );
+
+        $kvData = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        foreach ($kvData as $data) {
+            $deliveryExecution->addValue($data['monitoring_key'], $data['monitoring_value']);
+        }
+        return $kvData;
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function migrateDeliveryExecutionKvDataToExtraColumn(DeliveryMonitoringData $deliveryExecution)
+    {
+        if ($this->getOption('wet-run')) {
+            if ($this->monitoringService->partialSave($deliveryExecution)) {
+                $this->updated++;
+            } else {
+                throw new Exception(sprintf(
+                    'Unable to save delivery execution %s',
+                    $deliveryExecution->get()[DeliveryMonitoringService::DELIVERY_EXECUTION_ID]
+                ));
+            }
+        } else {
+            $this->updated++;
+        }
+    }
+
+    private function deleteDeliveryExecutionKvData(DeliveryMonitoringData $deliveryExecution, array $kvData): void
+    {
+        if ($this->getOption('deleteKv')) {
+            if ($this->getOption('wet-run')) {
+                $this->deleted += $this->monitoringService->getPersistence()->exec(
+                    'DELETE FROM kv_delivery_monitoring WHERE parent_id = ?',
+                    [$deliveryExecution->get()[DeliveryMonitoringService::DELIVERY_EXECUTION_ID]]
+                );
+            }  else {
+                $this->deleted += count($kvData);
+            }
+        }
+    }
+
+    private function createScriptReport(): Report
+    {
+        $wetrun = $this->getOption('wet-run');
+        $report = Report::createInfo();
+        $report->add(Report::createSuccess(sprintf('Saved delivery execution: %s', $this->updated)));
+        $report->add(Report::createSuccess(sprintf('ExtraData removed from KV table: %s', $this->deleted)));
+        if ($wetrun) {
+            $report->add(new Report(Report::TYPE_SUCCESS, 'Script runtime executed in `WET_RUN` mode'));
+            $report->add(new Report(Report::TYPE_INFO,
+                'You can now check that `kv_delivery_monitoring` table is empty and delete it'
+            ));
+
+        } else {
+            $report->add(new Report(Report::TYPE_ERROR, 'Script runtime executed in `DRY_RUN` mode'));
+        }
+        return $report;
+    }
+}

--- a/test/unit/model/DeliveryMonitoringStorageTest.php
+++ b/test/unit/model/DeliveryMonitoringStorageTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -14,96 +15,121 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2018 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2018-2021 (original work) Open Assessment Technologies SA;
  *
  */
+
+declare(strict_types=1);
 
 namespace oat\taoProctoring\test\unit\model;
 
+use common_persistence_SqlPersistence;
+use core_kernel_classes_Resource;
+use oat\generis\test\TestCase;
+use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
 use oat\taoProctoring\model\monitorCache\DeliveryMonitoringService;
-use oat\taoProctoring\model\monitorCache\implementation\MonitoringStorage;
-use oat\tao\test\TaoPhpUnitTestRunner;
+use oat\taoProctoring\model\repository\MonitoringRepository;
 use oat\taoProctoring\scripts\install\db\DbSetup;
-use oat\taoProctoring\model\execution\DeliveryExecution;
 use oat\taoProctoring\model\monitorCache\DeliveryMonitoringData;
 use oat\generis\persistence\PersistenceManager;
 
-/**
- * class DeliveryMonitoringStorageTest
- *
- * Represents data model of delivery execution.
- *
- * @package oat\taoProctoring
- * @author Joel Bout <joel@taotesting.com>
- */
-class DeliveryMonitoringStorageTest extends TaoPhpUnitTestRunner
+class DeliveryMonitoringStorageTest extends TestCase
 {
-    public function testPartialSave()
+    /** @var PersistenceManager */
+    private $persistenceManager;
+
+    /** @var MonitoringRepository */
+    private $monitoringRepository;
+
+    /** @var common_persistence_SqlPersistence $persistence */
+    private $persistence;
+
+    protected function setUp(): void
     {
-        //$pm = $this->getSqlMock('monitoring');
-        $pm = $this->getPmMock();
-        DbSetup::generateTable($pm->getPersistenceById('monitoring'));
-        $sl = $this->getServiceLocatorMock([\common_persistence_Manager::SERVICE_ID => $pm]);
-        $deP = $this->prophesize(DeliveryExecution::class);
-        $deP->getIdentifier()->willReturn('http://test/deliveryExecution');
+        $this->persistence = $this->getSqlMock('monitoring')->getPersistenceById('monitoring');
 
-        $stateProphecy = $this->prophesize(\core_kernel_classes_Resource::class);
-        $stateProphecy->getUri()->willReturn(DeliveryExecution::STATE_PAUSED);
+        $this->persistenceManager = $this->createMock(PersistenceManager::class);
+        $this->persistenceManager
+            ->method('getPersistenceById')
+            ->with('monitoring')
+            ->willReturn($this->persistence);
 
-        $deP->getState()->willReturn($stateProphecy);
-        $de = $deP->reveal();
-        $storage = new MonitoringStorage([
-            MonitoringStorage::OPTION_PERSISTENCE => 'monitoring',
-            'use_update_multiple' => false,
-            'primary_columns' => DbSetup::getPrimaryColumns()
+        $dbSetup = new DbSetup();
+        $dbSetup->generateTable($this->persistence);
+
+        $this->monitoringRepository = new MonitoringRepository([
+            MonitoringRepository::OPTION_PERSISTENCE => 'monitoring',
+            MonitoringRepository::OPTION_USE_UPDATE_MULTIPLE => false,
+            MonitoringRepository::OPTION_PRIMARY_COLUMNS => $dbSetup->getPrimaryColumns()
         ]);
-        $storage->setServiceLocator($sl);
-        
-        // full save
-        $data = $storage->getData($de);
+        $this->monitoringRepository->setServiceLocator($this->getServiceLocatorMock([
+            PersistenceManager::SERVICE_ID => $this->persistenceManager
+        ]));
+    }
+
+    protected function tearDown(): void
+    {
+        $this->persistence->query('DROP TABLE delivery_monitoring');
+    }
+
+    public function testCreateMonitoringData(): DeliveryMonitoringData
+    {
+        $data = $this->monitoringRepository->getData($this->getDeliveryExecutionFixture());
         $this->assertInstanceOf(DeliveryMonitoringData::class, $data);
+
+        return $data;
+    }
+
+    /**
+     * @depends testCreateMonitoringData
+     */
+    public function testSave(DeliveryMonitoringData $data): void
+    {
         $data->update('a', '1');
         $data->update('b', '2');
-        $data->update(DeliveryMonitoringService::STATUS, DeliveryExecution::STATE_PAUSED);
-        $success = $storage->save($data);
-        $this->assertTrue($success);
-        
-        // partial save
-        $data2 = $storage->createMonitoringData($de);
-        $data2->update('a', '3');
-        $success = $storage->partialSave($data2);
-        $this->assertTrue($success);
+        $data->update(DeliveryMonitoringService::STATUS, DeliveryExecutionInterface::STATE_PAUSED);
+        $this->assertTrue($this->monitoringRepository->save($data));
 
-        // load and compare data
-        $data3 = $storage->getData($de);
-        $this->assertInstanceOf(DeliveryMonitoringData::class, $data3);
-        $dataArray = $data3->get();
+        $dataArray = $data->get();
         $this->assertArrayHasKey('a', $dataArray);
-        $this->assertEquals('3', $dataArray['a']);
+        $this->assertArrayHasKey('b', $dataArray);
+        $this->assertEquals('1', $dataArray['a']);
         $this->assertEquals('2', $dataArray['b']);
     }
 
-    private function getPmMock()
+    /**
+     * @depends testCreateMonitoringData
+     */
+    public function testPartialSave(DeliveryMonitoringData $data): void
     {
-        $sqlMock = $this->getSqlMock('monitoring');
-        $cacheMock = $this->getKvMock('cache');
-        $this->persistence = $sqlMock->getPersistenceById('monitoring');
+        $data->update('a', '3');
+        $this->assertTrue($this->monitoringRepository->partialSave($data));
 
-        $pmMock = $this->getMockBuilder(PersistenceManager::class)
-            ->setMethods(['getPersistenceById'])
-            ->getMock();
+        $dataArray = $data->get();
+        $this->assertArrayHasKey('a', $dataArray);
+        $this->assertEquals('3', $dataArray['a']);
 
-        $pmMock->method('getPersistenceById')
-            ->will($this->returnCallback(
-                function ($persistenceId) use ($sqlMock, $cacheMock) {
-                    if ($persistenceId === 'cache') {
-                        return $cacheMock->getPersistenceById('cache');
-                    }
-                    if ($persistenceId === 'monitoring') {
-                        return $sqlMock->getPersistenceById('monitoring');
-                    }
-                }
-            ));
-        return $pmMock;
+        $data->update('a', '4');
+        $this->assertTrue($this->monitoringRepository->partialSave($data));
+
+        $dataArray = $data->get();
+        $this->assertArrayHasKey('a', $dataArray);
+        $this->assertEquals('4', $dataArray['a']);
+    }
+
+    private function getDeliveryExecutionFixture(): DeliveryExecutionInterface
+    {
+        $state = $this->createConfiguredMock(
+            core_kernel_classes_Resource::class,
+            ['getUri' => DeliveryExecutionInterface::STATE_PAUSED]
+        );
+
+        return $this->createConfiguredMock(
+            DeliveryExecutionInterface::class,
+            [
+                'getIdentifier' => 'http://test/deliveryExecution',
+                'getState' => $state,
+            ]
+        );
     }
 }

--- a/test/unit/model/listener/MonitoringListenerTest.php
+++ b/test/unit/model/listener/MonitoringListenerTest.php
@@ -1,0 +1,148 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoProctoring\test\unit\model\listener;
+
+use core_kernel_classes_Resource;
+use oat\generis\test\TestCase;
+use oat\oatbox\user\User;
+use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
+use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionCreated;
+use oat\taoProctoring\model\listener\MonitoringListener;
+use oat\taoProctoring\model\monitorCache\implementation\DeliveryMonitoringData;
+use oat\taoProctoring\model\repository\MonitoringRepository;
+use oat\taoProctoring\model\TestSessionConnectivityStatusService;
+
+class MonitoringListenerTest extends TestCase
+{
+    /** @var MonitoringListener */
+    private $subject;
+
+    /** @var MonitoringRepository */
+    private $monitoringRepository;
+
+    protected function setUp(): void
+    {
+        $this->monitoringRepository = $this->createMock(MonitoringRepository::class);
+
+        $this->subject = new MonitoringListener();
+        $this->subject->setServiceLocator($this->getServiceLocatorMock([
+            MonitoringRepository::SERVICE_ID => $this->monitoringRepository,
+        ]));
+    }
+
+    public function testExecutionCreated(): void
+    {
+        $deliveryExecution = $this->getDeliveryExecutionFixture();
+
+        $monitoringData = new DeliveryMonitoringData(
+            $deliveryExecution,
+            []
+        );
+
+        $testSessionConnectivityStatusService = $this->createConfiguredMock(
+            TestSessionConnectivityStatusService::class, ['hasOnlineMode' => false]
+        );
+        $monitoringData->setServiceLocator($this->getServiceLocatorMock([
+            TestSessionConnectivityStatusService::SERVICE_ID => $testSessionConnectivityStatusService,
+        ]));
+
+        $this->monitoringRepository->method('createMonitoringData')->willReturn($monitoringData);
+
+        $this->monitoringRepository
+            ->method('save')
+            ->with($this->callback(
+                function (DeliveryMonitoringData $monitoringData) {
+                    $data = $monitoringData->get();
+
+                    $this->assertArrayHasKey('status', $data);
+                    $this->assertEquals(DeliveryExecutionInterface::STATE_PAUSED , $data['status']);
+
+                    $this->assertArrayHasKey('test_taker', $data);
+                    $this->assertEquals('user-identifier', $data['test_taker']);
+
+                    $this->assertArrayHasKey('delivery_id', $data);
+                    $this->assertEquals('http://test/deliveryExecutionUri', $data['delivery_id']);
+
+                    $this->assertArrayHasKey('delivery_name', $data);
+                    $this->assertEquals('deliveryExecutionUri', $data['delivery_name']);
+
+                    $this->assertArrayHasKey('start_time', $data);
+                    $this->assertEquals('019183843', $data['start_time']);
+
+                    $this->assertArrayHasKey('test_taker_first_name', $data);
+                    $this->assertEquals('name' , $data['test_taker_first_name']);
+
+                    $this->assertArrayHasKey('test_taker_last_name', $data);
+                    $this->assertEquals('name' , $data['test_taker_last_name']);
+
+                    $this->assertArrayHasKey('last_connect', $data);
+
+                    return true;
+                }
+            ))
+            ->willReturn(true);
+
+        $event = new DeliveryExecutionCreated(
+            $deliveryExecution,
+            $this->getUserFixture()
+        );
+
+        $this->subject->executionCreated($event);
+
+        // MonitoringData has been checked during Repository save()
+        $this->assertTrue(true);
+    }
+
+    private function getDeliveryExecutionFixture(): DeliveryExecutionInterface
+    {
+        $state = $this->createConfiguredMock(core_kernel_classes_Resource::class,
+            ['getUri' => DeliveryExecutionInterface::STATE_PAUSED,]
+        );
+
+        $delivery = $this->createConfiguredMock(core_kernel_classes_Resource::class,
+            ['getUri' => 'http://test/deliveryExecutionUri', 'getLabel' => 'deliveryExecutionUri',]
+        );
+
+        return $this->createConfiguredMock(
+            DeliveryExecutionInterface::class,
+            [
+                'getIdentifier' => 'http://test/deliveryExecution',
+                'getState' => $state,
+                'getUserIdentifier' => 'user-identifier',
+                'getDelivery' => $delivery,
+                'getStartTime' => '019183843',
+            ]
+        );
+    }
+
+    private function getUserFixture(): User
+    {
+        return $this->createConfiguredMock(
+            User::class,
+            [
+                'getIdentifier' => 'toto',
+                'getPropertyValues' => ['name']
+            ]
+        );
+    }
+}


### PR DESCRIPTION
**Ticket**
https://oat-sa.atlassian.net/browse/PR-520

**Description**
This PR aims to transcript proctoring improvements to latest version with possibility to configure. 
it includes:
- [Refactor to improve database access](https://oat-sa.atlassian.net/browse/PR-471) (https://github.com/oat-sa/extension-tao-proctoring/pull/892)
- [Script to migrate data](https://oat-sa.atlassian.net/browse/PR-495) ()
- [Script to update to new impl](https://oat-sa.atlassian.net/browse/PR-495) (https://github.com/oat-sa/extension-tao-proctoring/pull/895)

Also event listeners have been moved from DeliveryService to a new MonitoringListener.

**To test**
All these scenarios should be run with psql and mysql.
- Checkout this PR, install the plaftorm with this PR, pass a proctored DX
- Do not checkout this PR, install, pass a proctored DX then checkout this PR, update, and run the scripts
```
php index.php '\oat\taoProctoring\scripts\tools\MonitoringExtraFieldMigration' -h
```
You can still pass proctored DX