### PR TITLE
fix: delete oat-sa/extension-lti-outcomeui, add oat-sa/extension-tao-…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "oat-sa/extension-tao-delivery-rdf" : ">=14.0.0",
         "oat-sa/extension-tao-delivery" : ">=15.0.0",
         "oat-sa/extension-tao-eventlog" : ">=3.0.0",
-        "oat-sa/extension-lti-outcomeui" : ">=1.0.0",
+        "oat-sa/extension-tao-outcomeui" : ">=10.0.0",
         "oat-sa/extension-tao-testqti" : ">=41.0.0",
         "oat-sa/extension-tao-testtaker" : ">=8.0.0",
         "oat-sa/extension-tao-test" : ">=15.0.0",


### PR DESCRIPTION
[The ticket](https://oat-sa.atlassian.net/browse/TR-2217)

**delete oat-sa/extension-lti-outcomeui, add oat-sa/extension-tao-outcomeui**

How to test:
Actually, "extension-tao-proctoring" doesn't use "oat-sa/extension-lti-outcomeui" (you can check it by search the package's namespace in the proctoring package folder), and "oat-sa/extension-tao-outcomeui" is used in the package, but isn't declared in dependencies (you can also check it the same way). We guess, there was typing mistake when someone moved the package from manifest.php to composer.json and had made mistake between "lti" and "tao" strings.
