### PR TITLE
[Backport] fix: delete oat-sa/extension-lti-outcomeui, add oat-sa/extension-tao-outcomeui

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "oat-sa/extension-tao-delivery-rdf" : ">=14.0.0",
         "oat-sa/extension-tao-delivery" : ">=15.0.0",
         "oat-sa/extension-tao-eventlog" : ">=3.0.0",
-        "oat-sa/extension-lti-outcomeui" : ">=1.0.0",
+        "oat-sa/extension-tao-outcomeui" : ">=10.0.0",
         "oat-sa/extension-tao-testqti" : ">=41.0.0",
         "oat-sa/extension-tao-testtaker" : ">=8.0.0",
         "oat-sa/extension-tao-test" : ">=15.0.0",


### PR DESCRIPTION
For https://oat-sa.atlassian.net/browse/TR-2381

Backport onto new v20.1.1.1 for `tao-community 2021.10.2`:
- #905 