### PR TITLE
Remove the test-taker "paused" dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,13 @@ It is work in progress and will contain functionalities such as:
 * Assigning test-takers to tests
 * Validating test sessions
 * Log cheating attempts
+
+## Configuration options
+
+### Feature flags
+#### FEATURE_FLAG_PROCTOR_NOT_LAUNCH_PAUSE_MESSAGE
+
+Controls whether message is not sent when test is paused.
+
+- `"false"` – send the message. Default behavior.
+- `"true"` – does not send the message.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It is work in progress and will contain functionalities such as:
 ## Configuration options
 
 ### Feature flags
-#### FEATURE_FLAG_PROCTOR_NOT_LAUNCH_PAUSE_MESSAGE
+#### FEATURE_FLAG_SKIP_PAUSED_ASSESSMENT_DIALOG
 
 Controls whether message is not sent when test is paused.
 

--- a/model/implementation/TestRunnerMessageService.php
+++ b/model/implementation/TestRunnerMessageService.php
@@ -95,7 +95,7 @@ class TestRunnerMessageService extends QtiRunnerMessageService
      */
     protected function getPausedStateMessage(AssessmentTestSession $testSession)
     {
-        if ($this->cantReturnPauseStateMessage()) {
+        if (false === $this->isPausedDialogRequired()) {
             return '';
         }
 
@@ -120,9 +120,9 @@ class TestRunnerMessageService extends QtiRunnerMessageService
         return parent::getTerminatedStateMessage($testSession);
     }
 
-    private function cantReturnPauseStateMessage(): bool
+    private function isPausedDialogRequired(): bool
     {
-        return $this->getFeatureFlagChecker()->isEnabled(self::FEATURE_FLAG_PROCTOR_NOT_LAUNCH_PAUSE_MESSAGE);
+        return false === $this->getFeatureFlagChecker()->isEnabled(self::FEATURE_FLAG_SKIP_PAUSED_ASSESSMENT_DIALOG);
     }
 
     private function getFeatureFlagChecker(): FeatureFlagCheckerInterface

--- a/model/implementation/TestRunnerMessageService.php
+++ b/model/implementation/TestRunnerMessageService.php
@@ -40,7 +40,7 @@ class TestRunnerMessageService extends QtiRunnerMessageService
     /**
      * @var string Controls whether a pause message is not sent on status, default false
      */
-    private const FEATURE_FLAG_PROCTOR_NOT_LAUNCH_PAUSE_MESSAGE = 'FEATURE_FLAG_PROCTOR_NOT_LAUNCH_PAUSE_MESSAGE';
+    private const FEATURE_FLAG_SKIP_PAUSED_ASSESSMENT_DIALOG = 'FEATURE_FLAG_SKIP_PAUSED_ASSESSMENT_DIALOG';
 
     /** Proctor roles option in options. */
     const PROCTOR_ROLES_OPTION = 'proctorRoles';

--- a/test/unit/model/implementation/TestRunnerMessageServiceTest.php
+++ b/test/unit/model/implementation/TestRunnerMessageServiceTest.php
@@ -92,12 +92,7 @@ final class TestRunnerMessageServiceTest extends TestCase
         ];
     }
 
-    /**
-     * @param array $options
-     * @param ServiceManager $serviceManager
-     * @return TestRunnerMessageService
-     */
-    private function getClassTestRunnerMessageService($serviceManager, $options = []): TestRunnerMessageService
+    private function getClassTestRunnerMessageService(ServiceManager $serviceManager, array $options = []): TestRunnerMessageService
     {
         return new class ($options, $serviceManager) extends TestRunnerMessageService {
             /**
@@ -105,24 +100,17 @@ final class TestRunnerMessageServiceTest extends TestCase
              */
             private $serviceManager;
 
-            public function __construct($options = [], $serviceManager)
+            public function __construct(array $options = [], ServiceManager $serviceManager)
             {
                 parent::__construct($options);
                 $this->serviceManager = $serviceManager;
             }
 
-            /**
-             * @param AssessmentTestSession $testSession
-             * @return string
-             */
             public function getPausedStateMessageFrom(AssessmentTestSession $testSession): string
             {
                 return parent::getPausedStateMessage($testSession);
             }
 
-            /**
-             * @return ServiceManager
-             */
             public function getServiceLocator(): ServiceManager
             {
                 return $this->serviceManager;

--- a/test/unit/model/implementation/TestRunnerMessageServiceTest.php
+++ b/test/unit/model/implementation/TestRunnerMessageServiceTest.php
@@ -1,4 +1,21 @@
 <?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021  (original work) Open Assessment Technologies SA;
+ */
 
 declare(strict_types=1);
 

--- a/test/unit/model/implementation/TestRunnerMessageServiceTest.php
+++ b/test/unit/model/implementation/TestRunnerMessageServiceTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoProctoring\test\unit\model\implementation;
+
+use oat\oatbox\service\ServiceManager;
+use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
+use oat\taoProctoring\model\implementation\TestRunnerMessageService;
+use qtism\runtime\tests\AssessmentTestSession;
+use PHPUnit\Framework\TestCase;
+
+final class TestRunnerMessageServiceTest extends TestCase
+{
+    /**
+     * @var TestRunnerMessageService
+     */
+    private $testRunnerMessageService;
+
+    /**
+     * @var ServiceManager
+     */
+    private $serviceManager;
+
+    /**
+     * @var FeatureFlagCheckerInterface
+     */
+    private $featureFlagChecker;
+
+    /**
+     * @var AssessmentTestSession
+     */
+    private $assessmentTestSession;
+
+    protected function setUp(): void
+    {
+        $this->testRunnerMessageService = new TestRunnerMessageService();
+        $this->featureFlagChecker = $this->createMock(FeatureFlagCheckerInterface::class);
+        $this->serviceManager = $this->createMock(ServiceManager::class);
+        $this->serviceManager->method('get')->willReturn($this->featureFlagChecker);
+        $this->assessmentTestSession = $this->createMock(AssessmentTestSession::class);
+    }
+
+    /**
+     * @dataProvider providerProctorRoles
+     */
+    public function testGetPausedStateMessage(array $proctorRoles, string $message): void
+    {
+        $testRunnerMessageService = $this->getClassTestRunnerMessageService($this->serviceManager, ['proctorRoles' => $proctorRoles]);
+        $pausedStateMessage = $testRunnerMessageService->getPausedStateMessageFrom($this->assessmentTestSession);
+
+        self::assertSame($message, $pausedStateMessage);
+    }
+
+    public function testGetPausedStateMessageReturnEmpty(): void
+    {
+        $this->featureFlagChecker->method('isEnabled')->willReturn(true);
+        $testRunnerMessageService = $this->getClassTestRunnerMessageService($this->serviceManager);
+        $pausedStateMessage = $testRunnerMessageService->getPausedStateMessageFrom($this->assessmentTestSession);
+
+        self::assertEmpty($pausedStateMessage);
+    }
+
+    public function providerProctorRoles(): array
+    {
+        return [
+            'message with defined roles' => [
+                (new \common_session_AnonymousSession())->getUserRoles(),
+                'The assessment has been suspended. To resume your assessment, please relaunch it and contact your proctor if required.'
+            ],
+            'message without defined roles' => [
+                [],
+                'The assessment has been suspended. To resume your assessment, please relaunch it.'
+            ]
+        ];
+    }
+
+    /**
+     * @param array $options
+     * @param ServiceManager $serviceManager
+     * @return TestRunnerMessageService
+     */
+    private function getClassTestRunnerMessageService($serviceManager, $options = []): TestRunnerMessageService
+    {
+        return new class ($options, $serviceManager) extends TestRunnerMessageService {
+            /**
+             * @var ServiceManager
+             */
+            private $serviceManager;
+
+            public function __construct($options = [], $serviceManager)
+            {
+                parent::__construct($options);
+                $this->serviceManager = $serviceManager;
+            }
+
+            /**
+             * @param AssessmentTestSession $testSession
+             * @return string
+             */
+            public function getPausedStateMessageFrom(AssessmentTestSession $testSession): string
+            {
+                return parent::getPausedStateMessage($testSession);
+            }
+
+            /**
+             * @return ServiceManager
+             */
+            public function getServiceLocator(): ServiceManager
+            {
+                return $this->serviceManager;
+            }
+        };
+    }
+}


### PR DESCRIPTION
# [TR-2500](https://oat-sa.atlassian.net/browse/TR-2500)

## Changelog
- feat: add the feat flag to control the pause message
- test: add new tests for TestRunnerMessageService
- docs: add the new configuration options to README.md

## How to test
1. Set [taoProctoring](https://github.com/oat-sa/extension-tao-proctoring) up
2. Run a proctored assessment as a test taker
3. Authorize the assessment as a proctor
4. Pause the assessment as the test taker
5. Observe that the message is sent to the test taker
6. Set `FEATURE_FLAG_PROCTOR_NOT_LAUNCH_PAUSE_MESSAGE="true"` environment variable
8. Restart the assessment as the test taker
9. Pause the assessment as the test taker
10. Observe that it does not show the message to the test-taker and reload the page