### PR TITLE
Fix TR-3297 proctoring page sorting

### DIFF
--- a/model/repository/MonitoringRepository.php
+++ b/model/repository/MonitoringRepository.php
@@ -466,7 +466,13 @@ class MonitoringRepository extends ConfigurableService implements DeliveryMonito
 
             if (!in_array($ruleParts[1], $primaryTableColumns)) {
                 $colName = $ruleParts[1];
+                if (in_array($this->getPlatformName(), ['mysql','sqlite'])) {
+                    $colName = sprintf('JSON_EXTRACT(t.%s, \'$.%s\')', self::COLUMN_EXTRA_DATA, $colName);
+                } else {
+                    $colName = sprintf('t.%s -> \'%s\'', self::COLUMN_EXTRA_DATA, $colName);
+                }
                 $this->queryParams[] = $colName;
+                $sortingColumn ='?';
             } else {
                 $sortingColumn = $ruleParts[1];
             }


### PR DESCRIPTION
# [TR-3297](https://oat-sa.atlassian.net/browse/TR-3297)

## Goal
Need to fix `MonitoringRepository` order clause building for `not primary columns` stored in `json extra data field`

## Changelog
- fix: order cause building in `MonitoringRepository` 

## How to test / use
1. Update `extension-tao-proctoring` by branch on CG instance with `jsonb` not primary field
2. Order proctoring monitoring table by this field
3. Receive data instead of error