### PR TITLE
Backport TR-3297

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'Proctoring',
     'description' => 'Proctoring for deliveries',
     'license' => 'GPL-2.0',
-    'version' => '19.20.7.2',
+    'version' => '19.20.7.3',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao'            => '>=45.6.3',

--- a/model/repository/MonitoringRepository.php
+++ b/model/repository/MonitoringRepository.php
@@ -705,7 +705,7 @@ class MonitoringRepository extends ConfigurableService implements DeliveryMonito
             } else if (in_array($this->getPlatformName(), ['mysql','sqlite'])) {
                 $whereClause .= sprintf(' JSON_EXTRACT(t.%s, \'$.%s\') %s ', self::COLUMN_EXTRA_DATA, trim($key), $op);
             } else {
-                $isLikeSearch = isset($op) && stripos(strtolower($op), 'like') !== false;
+                $isLikeSearch = isset($op) && stripos($op, 'like') !== false;
                 $value = is_array($value) ? $value : [$value];
                 if ($isLikeSearch) {
                     $jsonDataAccessOperator = '->>';

--- a/model/repository/MonitoringRepository.php
+++ b/model/repository/MonitoringRepository.php
@@ -461,7 +461,10 @@ class MonitoringRepository extends ConfigurableService implements DeliveryMonito
         $order = explode(',', $order);
         $result = [];
         foreach ($order as $orderRule) {
-            $result[] = $this->buildSingleOrderRule($orderRule);
+            $orderStmt = $this->buildSingleOrderRule($orderRule);
+            if ($orderStmt) {
+                $result[] = $orderStmt;
+            }
         }
 
         return implode(', ', $result);
@@ -493,8 +496,8 @@ class MonitoringRepository extends ConfigurableService implements DeliveryMonito
             $sortingColumn = $orderBy;
         }
 
-        return isset($type) && $type === 'numeric'
-            ? $this->buildNumericOrderWithCastingToDecimal($sortingColumn, $orderRule)
+        return $type === 'numeric'
+            ? $this->buildNumericOrderWithCastingToDecimal($sortingColumn, $order)
             : sprintf('%s %s', $sortingColumn, $order);
     }
 

--- a/model/repository/MonitoringRepository.php
+++ b/model/repository/MonitoringRepository.php
@@ -482,8 +482,7 @@ class MonitoringRepository extends ConfigurableService implements DeliveryMonito
             } else {
                 $colName = sprintf('t.%s -> \'%s\'', self::COLUMN_EXTRA_DATA, $colName);
             }
-            $this->queryParams[] = $colName;
-            $sortingColumn = '?';
+            $sortingColumn = $colName;
         } else {
             $sortingColumn = $ruleParts[1];
         }

--- a/model/repository/MonitoringRepository.php
+++ b/model/repository/MonitoringRepository.php
@@ -480,7 +480,7 @@ class MonitoringRepository extends ConfigurableService implements DeliveryMonito
             if (in_array($this->getPlatformName(), ['mysql', 'sqlite'])) {
                 $colName = sprintf('JSON_EXTRACT(t.%s, \'$.%s\')', self::COLUMN_EXTRA_DATA, $colName);
             } else {
-                $colName = sprintf('t.%s -> \'%s\'', self::COLUMN_EXTRA_DATA, $colName);
+                $colName = sprintf('t.%s ->> \'%s\'', self::COLUMN_EXTRA_DATA, $colName);
             }
             $sortingColumn = $colName;
         } else {

--- a/model/repository/MonitoringRepository.php
+++ b/model/repository/MonitoringRepository.php
@@ -696,7 +696,7 @@ class MonitoringRepository extends ConfigurableService implements DeliveryMonito
                     $op = $matches[1] ? $matches[1] : '=';
                 }
                 $op .= ' ? ';
-                $value = $toLower ? strtolower($matches[2]) : $matches[2];
+                $value = trim($toLower ? strtolower($matches[2]) : $matches[2]);
             }
 
             if (in_array($key, $primaryColumns)) {

--- a/model/repository/MonitoringRepository.php
+++ b/model/repository/MonitoringRepository.php
@@ -466,7 +466,13 @@ class MonitoringRepository extends ConfigurableService implements DeliveryMonito
 
             if (!in_array($ruleParts[1], $primaryTableColumns)) {
                 $colName = $ruleParts[1];
+                if (in_array($this->getPlatformName(), ['mysql','sqlite'])) {
+                    $colName = sprintf('JSON_EXTRACT(t.%s, \'$.%s\')', self::COLUMN_EXTRA_DATA, $colName);
+                } else {
+                    $colName = sprintf('t.%s -> \'%s\'', self::COLUMN_EXTRA_DATA, $colName);
+                }
                 $this->queryParams[] = $colName;
+                $sortingColumn ='?';
             } else {
                 $sortingColumn = $ruleParts[1];
             }

--- a/model/repository/MonitoringRepository.php
+++ b/model/repository/MonitoringRepository.php
@@ -487,8 +487,13 @@ class MonitoringRepository extends ConfigurableService implements DeliveryMonito
             $sortingColumn = $ruleParts[1];
         }
 
+        // Hotfix for sorting by authorised_by column which can contain a curd number or user URI
+        $numericPart = in_array($this->getPlatformName(), ['mysql', 'sqlite'])
+            ? sprintf("cast(NULLIF(%s, '') as SIGNED) %s", $sortingColumn, $ruleParts[2])
+            : sprintf("cast(NULLIF(regexp_replace(%s, '\D', '', 'g'), '') as decimal) %s", $sortingColumn, $ruleParts[2]);
+
         return isset($ruleParts[3]) && $ruleParts[3] === 'numeric'
-            ? sprintf("cast(nullif(%s, '') as decimal) %s", $sortingColumn, $ruleParts[2])
+            ? $numericPart
             : sprintf('%s %s', $sortingColumn, $ruleParts[2] ?? 'ASC');
     }
 


### PR DESCRIPTION
# [TR-3297](https://oat-sa.atlassian.net/browse/TR-3297)

## Changelog

- chore: bump patch version in package manifest Kiryl Poyu 3 minutes ago
- refactor: remove unnecessary `isset` check, add empty value check in building of order statement 
- refactor: extract order to variables, move building numeric order statement method
- fix: ordering `authorized_by` field
- fix: trim for like search
- fix: cast json values to text for casting to decimal at numeric ordering
- fix:remove `strtolower` at in case-insensitive `stripos` usage
- fix: remove inserting `extra_data` field sorting by as query parameter
- fix: add type casting to `text` for `like` search condition in jsonb `extra_data_column`
- refactor: extract method from foreach body
- fix: fix not primary column sorting