### PR TITLE
feat!: update dependencies for dbal3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
   "require": {
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
     "sinergi/browser-detector": "^6.0.2",
-    "oat-sa/generis": ">=16.2.2",
-    "oat-sa/tao-core": ">=54.49.5",
+    "oat-sa/generis": ">=17.0.0",
+    "oat-sa/tao-core": ">=56.0.0",
     "oat-sa/extension-tao-delivery-rdf": ">=14.0.0",
     "oat-sa/extension-tao-delivery": ">=15.0.0",
     "oat-sa/extension-tao-eventlog": ">=3.0.0",

--- a/model/deliveryLog/implementation/RdsDeliveryLogService.php
+++ b/model/deliveryLog/implementation/RdsDeliveryLogService.php
@@ -106,7 +106,7 @@ class RdsDeliveryLogService extends ConfigurableService implements DeliveryLog
 
         $queryBuilder->orderBy(static::ID, 'ASC');
 
-        $data = $queryBuilder->execute()->fetchAll(\PDO::FETCH_ASSOC);
+        $data = $queryBuilder->executeQuery()->fetchAllAssociative();
 
         $result = $this->decodeValues($data);
 
@@ -137,7 +137,7 @@ class RdsDeliveryLogService extends ConfigurableService implements DeliveryLog
             ->where(self::DELIVERY_EXECUTION_ID . '=:delivery_execution_id')
             ->setParameter('delivery_execution_id', $request->getDeliveryExecution()->getIdentifier());
 
-        return ($queryBuilder->execute() > 0);
+        return ($queryBuilder->executeStatement() > 0);
     }
 
     /**
@@ -212,7 +212,7 @@ class RdsDeliveryLogService extends ConfigurableService implements DeliveryLog
         }
 
         $shouldDecodeData = isset($options['shouldDecodeData']) ? (bool)$options['shouldDecodeData'] : true;
-        $data             = $queryBuilder->execute()->fetchAll(\PDO::FETCH_ASSOC);
+        $data             = $queryBuilder->executeQuery()->fetchAllAssociative();
         if ($shouldDecodeData) {
             $result = $this->decodeValues($data);
         } else {

--- a/model/helper/SqlParameterBindingTrait.php
+++ b/model/helper/SqlParameterBindingTrait.php
@@ -70,16 +70,16 @@ trait SqlParameterBindingTrait
             $normalizedKey = $hasLeadingColon ? substr($keyStr, 1) : $key;
             $counterpart = $hasLeadingColon ? $normalizedKey : ':' . $keyStr;
             if (array_key_exists($counterpart, $params) && $params[$counterpart] !== $value) {
-                throw new InvalidArgumentException(
-                    sprintf(
-                        'Conflicting named parameter "%s": both ":%s" and "%s" are present with different values (%s vs %s).',
-                        $normalizedKey,
-                        $normalizedKey,
-                        $normalizedKey,
-                        self::formatParamValue($value),
-                        self::formatParamValue($params[$counterpart])
-                    )
+                $msg = sprintf(
+                    'Conflicting named parameter "%s": both ":%s" and "%s" are present with different values '
+                    . '(%s vs %s).',
+                    $normalizedKey,
+                    $normalizedKey,
+                    $normalizedKey,
+                    self::formatParamValue($value),
+                    self::formatParamValue($params[$counterpart])
                 );
+                throw new InvalidArgumentException($msg);
             }
             $normalized[$normalizedKey] = $value;
         }

--- a/model/helper/SqlParameterBindingTrait.php
+++ b/model/helper/SqlParameterBindingTrait.php
@@ -42,7 +42,8 @@ trait SqlParameterBindingTrait
      */
     protected function bindMissingNamedParameters(string $sql, array $params, bool $fillMissingWithNull = false): array
     {
-        if (preg_match_all('/:(\w+)/', $sql, $matches)) {
+        // (?<!:) avoids matching :: as a named parameter (e.g. PostgreSQL ::jsonb cast)
+        if (preg_match_all('/(?<!:):(\w+)/', $sql, $matches)) {
             $missing = [];
             foreach (array_unique($matches[1]) as $name) {
                 $keyWithColon = ':' . $name;

--- a/model/helper/SqlParameterBindingTrait.php
+++ b/model/helper/SqlParameterBindingTrait.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoProctoring\model\helper;
+
+use InvalidArgumentException;
+
+/**
+ * Trait to normalize SQL named parameters and optionally validate or fill missing ones.
+ */
+trait SqlParameterBindingTrait
+{
+    /**
+     * Ensure every named parameter in the SQL has a bound value and keys match
+     * DBAL expectation (name without colon). Avoids "Named parameter X does not have a bound value".
+     *
+     * @param string $sql
+     * @param array $params
+     * @param bool $fillMissingWithNull If true, missing parameters are set to null; if false, throws on missing.
+     * @return array<string, mixed>
+     * @throws InvalidArgumentException When a named parameter is missing and $fillMissingWithNull is false.
+     */
+    protected function bindMissingNamedParameters(string $sql, array $params, bool $fillMissingWithNull = false): array
+    {
+        if (preg_match_all('/:(\w+)/', $sql, $matches)) {
+            $missing = [];
+            foreach (array_unique($matches[1]) as $name) {
+                $keyWithColon = ':' . $name;
+                if (!array_key_exists($keyWithColon, $params) && !array_key_exists($name, $params)) {
+                    if ($fillMissingWithNull) {
+                        $params[$name] = null;
+                    } else {
+                        $missing[] = $name;
+                    }
+                }
+            }
+            if ($missing !== []) {
+                $snippet = strlen($sql) > 200 ? substr($sql, 0, 200) . '...' : $sql;
+                throw new InvalidArgumentException(
+                    'Missing named parameter(s) for SQL: ' . implode(', ', $missing) . '. SQL snippet: ' . $snippet
+                );
+            }
+        }
+        $normalized = [];
+        foreach ($params as $key => $value) {
+            $keyStr = (string) $key;
+            $normalized[strpos($keyStr, ':') === 0 ? substr($keyStr, 1) : $key] = $value;
+        }
+        return $normalized;
+    }
+}

--- a/model/helper/SqlParameterBindingTrait.php
+++ b/model/helper/SqlParameterBindingTrait.php
@@ -42,7 +42,8 @@ trait SqlParameterBindingTrait
      */
     protected function bindMissingNamedParameters(string $sql, array $params, bool $fillMissingWithNull = false): array
     {
-        // (?<!:) avoids matching :: as a named parameter (e.g. PostgreSQL ::jsonb cast)
+        // Matches named placeholders :name (not :: cast). Note: does not skip quoted strings or
+        // SQL comments—e.g. ':x' inside a string literal would still be treated as a placeholder.
         if (preg_match_all('/(?<!:):(\w+)/', $sql, $matches)) {
             $missing = [];
             foreach (array_unique($matches[1]) as $name) {

--- a/model/monitorCache/implementation/MonitoringStorage.php
+++ b/model/monitorCache/implementation/MonitoringStorage.php
@@ -347,8 +347,7 @@ class MonitoringStorage extends ConfigurableService implements DeliveryMonitorin
             'GROUP BY t.' . self::DELIVERY_EXECUTION_ID . ') as count_q';
 
         $stmt = $this->getPersistence()->query($sql, $this->queryParams);
-        $result = $stmt->fetchOne();
-        return (int) $result;
+        return (int) $stmt->fetchOne();
     }
 
     /**

--- a/scripts/tools/MonitoringExtraFieldMigration.php
+++ b/scripts/tools/MonitoringExtraFieldMigration.php
@@ -197,7 +197,7 @@ class MonitoringExtraFieldMigration extends ScriptAction
         );
         $stmt = $this->monitoringService->getPersistence()->query($sql, array_keys($deliveryExecutions));
 
-        $kvData = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $kvData = $stmt->fetchAllAssociative();
         foreach ($kvData as $data) {
             $deliveryExecutions[$data['parent_id']]->addValue($data['monitoring_key'], $data['monitoring_value']);
         }

--- a/scripts/update/AlterDeliveryMonitoringTables.php
+++ b/scripts/update/AlterDeliveryMonitoringTables.php
@@ -115,7 +115,7 @@ class AlterDeliveryMonitoringTables extends \common_ext_action_InstallAction
     protected function updateLinks()
     {
         $stmt = $this->persistence->query('SELECT * FROM delivery_monitoring');
-        $parentRows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+        $parentRows = $stmt->fetchAllAssociative();
 
         foreach ($parentRows as $parentRow) {
             $this->persistence->exec("UPDATE kv_delivery_monitoring SET parent_id=?

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -442,7 +442,7 @@ class Updater extends common_ext_ExtensionUpdater
                 ->set('monitoring_value', "REPLACE(monitoring_value, 's', '')")
                 ->where('monitoring_key = ? and monitoring_value is not null')
                 ->setParameters(['remaining_time'])
-                ->execute();
+                ->executeStatement();
 
             $this->setVersion('5.12.0');
         }

--- a/test/integration/deliveryLog/RdsDeliveryLogServiceTest.php
+++ b/test/integration/deliveryLog/RdsDeliveryLogServiceTest.php
@@ -225,6 +225,6 @@ class RdsDeliveryLogServiceTest extends TaoPhpUnitTestRunner
         $sql = 'SELECT * FROM ' . RdsDeliveryLogService::TABLE_NAME .
             ' WHERE ' . RdsDeliveryLogService::DELIVERY_EXECUTION_ID . '=?';
 
-        return $this->persistence->query($sql, [$id])->fetchAll();
+        return $this->persistence->query($sql, [$id])->fetchAllAssociative();
     }
 }

--- a/test/integration/monitorCache/DeliveryMonitoringServiceTest.php
+++ b/test/integration/monitorCache/DeliveryMonitoringServiceTest.php
@@ -561,7 +561,7 @@ class DeliveryMonitoringServiceTest extends TaoPhpUnitTestRunner
         $sql = 'SELECT * FROM ' . $service::TABLE_NAME .
             ' WHERE ' . $service::COLUMN_DELIVERY_EXECUTION_ID . '=?';
 
-        return $this->persistence->query($sql, [$id])->fetchAll();
+        return $this->persistence->query($sql, [$id])->fetchAllAssociative();
     }
 
     protected function getKvRecordsByParentId($parentId)
@@ -570,7 +570,7 @@ class DeliveryMonitoringServiceTest extends TaoPhpUnitTestRunner
         $sql = 'SELECT * FROM ' . $service::KV_TABLE_NAME .
             ' WHERE ' . $service::KV_COLUMN_PARENT_ID . '=?';
 
-        return $this->persistence->query($sql, [$parentId])->fetchAll(\PDO::FETCH_ASSOC);
+        return $this->persistence->query($sql, [$parentId])->fetchAllAssociative();
     }
 
     protected function getDeliveryExecution($id = null, $state = null)

--- a/test/unit/model/helper/SqlParameterBindingTraitTest.php
+++ b/test/unit/model/helper/SqlParameterBindingTraitTest.php
@@ -158,6 +158,24 @@ class SqlParameterBindingTraitTest extends TestCase
         $result = $this->bind($sql, $params, false);
         $this->assertSame([], $result);
     }
+
+    public function testSameValueForColonAndPlainKeyDoesNotThrow(): void
+    {
+        $sql = 'SELECT * FROM t WHERE id = :id';
+        $params = ['id' => 1, ':id' => 1];
+        $result = $this->bind($sql, $params, false);
+        $this->assertSame(['id' => 1], $result);
+    }
+
+    public function testConflictingColonAndPlainKeyThrowsWithParameterNameAndValues(): void
+    {
+        $sql = 'SELECT * FROM t WHERE id = :id';
+        $params = ['id' => 1, ':id' => 2];
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Conflicting named parameter "id"');
+        $this->expectExceptionMessage('different values');
+        $this->bind($sql, $params, false);
+    }
 }
 
 /** Test double that uses the trait so the real parameter-checking flow is exercised. */

--- a/test/unit/model/helper/SqlParameterBindingTraitTest.php
+++ b/test/unit/model/helper/SqlParameterBindingTraitTest.php
@@ -1,0 +1,167 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoProctoring\test\unit\model\helper;
+
+use InvalidArgumentException;
+use oat\generis\test\TestCase;
+use oat\taoProctoring\model\helper\SqlParameterBindingTrait;
+
+/**
+ * Unit tests for SqlParameterBindingTrait (parameter-checking flow and regex behaviour).
+ */
+class SqlParameterBindingTraitTest extends TestCase
+{
+    /** @var SqlParameterBindingTraitTestDouble */
+    private $subject;
+
+    /** @var \ReflectionMethod */
+    private $bindMethod;
+
+    protected function setUp(): void
+    {
+        $this->subject = new SqlParameterBindingTraitTestDouble();
+        $this->bindMethod = new \ReflectionMethod($this->subject, 'bindMissingNamedParameters');
+        $this->bindMethod->setAccessible(true);
+    }
+
+    private function bind(string $sql, array $params, bool $fillMissingWithNull = false): array
+    {
+        return $this->bindMethod->invoke($this->subject, $sql, $params, $fillMissingWithNull);
+    }
+
+    public function testNamedParamWithColonKeyReturnsNormalized(): void
+    {
+        $sql = 'SELECT * FROM t WHERE id = :id';
+        $params = [':id' => 1];
+        $result = $this->bind($sql, $params, false);
+        $this->assertSame(['id' => 1], $result);
+    }
+
+    public function testNamedParamWithNormalizedKeyReturnsNormalized(): void
+    {
+        $sql = 'SELECT * FROM t WHERE id = :id';
+        $params = ['id' => 1];
+        $result = $this->bind($sql, $params, false);
+        $this->assertSame(['id' => 1], $result);
+    }
+
+    public function testDuplicateParamNamesInSqlOnlyRequireOneBinding(): void
+    {
+        $sql = 'UPDATE t SET a = :x WHERE b = :x';
+        $params = ['x' => 10];
+        $result = $this->bind($sql, $params, false);
+        $this->assertSame(['x' => 10], $result);
+    }
+
+    public function testPostgresqlDoubleColonCastNotTreatedAsParam(): void
+    {
+        $sql = 'SELECT :payload::jsonb';
+        $params = ['payload' => '{}'];
+        $result = $this->bind($sql, $params, false);
+        $this->assertSame(['payload' => '{}'], $result);
+    }
+
+    public function testPostgresqlCastWithNoNamedParamReturnsNormalizedOnly(): void
+    {
+        $sql = 'SELECT 1::integer';
+        $params = [];
+        $result = $this->bind($sql, $params, false);
+        $this->assertSame([], $result);
+    }
+
+    public function testMissingParameterThrowsWhenFillMissingWithNullFalse(): void
+    {
+        $sql = 'SELECT * FROM t WHERE id = :id';
+        $params = [];
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing named parameter(s) for SQL: id');
+        $this->expectExceptionMessage('SQL snippet:');
+        $this->bind($sql, $params, false);
+    }
+
+    public function testExceptionMessageContainsSqlSnippet(): void
+    {
+        $sql = 'SELECT * FROM t WHERE id = :id AND name = :name';
+        $params = ['id' => 1];
+        try {
+            $this->bind($sql, $params, false);
+            $this->fail('Expected InvalidArgumentException');
+        } catch (InvalidArgumentException $e) {
+            $this->assertStringContainsString('name', $e->getMessage());
+            $this->assertStringContainsString('SQL snippet:', $e->getMessage());
+            $this->assertStringContainsString('SELECT * FROM t WHERE id = :id', $e->getMessage());
+        }
+    }
+
+    public function testLongSqlSnippetTruncatedInException(): void
+    {
+        $longSql = 'SELECT ' . str_repeat('x', 300) . ' WHERE id = :id';
+        $params = [];
+        try {
+            $this->bind($longSql, $params, false);
+            $this->fail('Expected InvalidArgumentException');
+        } catch (InvalidArgumentException $e) {
+            $this->assertStringContainsString('SQL snippet:', $e->getMessage());
+            $this->assertStringContainsString('...', $e->getMessage());
+        }
+    }
+
+    public function testMissingParameterFilledWithNullWhenFillMissingWithNullTrue(): void
+    {
+        $sql = 'SELECT * FROM t WHERE id = :id';
+        $params = [];
+        $result = $this->bind($sql, $params, true);
+        $this->assertSame(['id' => null], $result);
+    }
+
+    public function testMultipleMissingFilledWithNullWhenFillMissingWithNullTrue(): void
+    {
+        $sql = 'SELECT * FROM t WHERE a = :a AND b = :b';
+        $params = [];
+        $result = $this->bind($sql, $params, true);
+        $this->assertSame(['a' => null, 'b' => null], $result);
+    }
+
+    public function testNoNamedParamsInSqlReturnsNormalizedParamsOnly(): void
+    {
+        $sql = 'SELECT 1';
+        $params = [':foo' => 'bar'];
+        $result = $this->bind($sql, $params, false);
+        $this->assertSame(['foo' => 'bar'], $result);
+    }
+
+    public function testEmptyParamsAndNoPlaceholdersReturnsEmptyArray(): void
+    {
+        $sql = 'SELECT 1';
+        $params = [];
+        $result = $this->bind($sql, $params, false);
+        $this->assertSame([], $result);
+    }
+}
+
+/** Test double that uses the trait so the real parameter-checking flow is exercised. */
+class SqlParameterBindingTraitTestDouble
+{
+    use SqlParameterBindingTrait;
+}


### PR DESCRIPTION
Update dbal v3 dependencies AUT-4457



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependencies: oat-sa/generis to >=17.0.0, oat-sa/tao-core to >=56.0.0

* **Refactor**
  * Modernized database access across delivery logging, monitoring, migration and upgrade paths for compatibility with the newer DB layer.
  * Added centralized SQL parameter-binding helper to normalize and validate named parameters.

* **Tests**
  * Updated integration tests and helpers to align with the revised DB-access behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->